### PR TITLE
umash.c: make select_ptr slightly less opaque to compilers

### DIFF
--- a/umash.c
+++ b/umash.c
@@ -474,7 +474,7 @@ select_ptr(bool cond, const void *then, const void *otherwise)
 
 #ifdef __GNUC__
 	/* Force strict evaluation of both arguments. */
-	__asm__("" : "+r"(then), "+r"(otherwise));
+	__asm__("" :: "r"(then), "r"(otherwise));
 #endif
 
 	ret = (cond) ? then : otherwise;


### PR DESCRIPTION
Read the input pointers, but don't pretend we overwrite them.

Preserves the conditional move on gcc 8.3; histograms show
clear separation between the improved code and 88edff1.

Seems to let clang do its thing unhindered.

Stats say none of the differences look statistically significant:

```
[(1,
  {'mean': Result(actual_value=-0.21535264320041564, judgement=0, m=15414, n=15414, num_trials=250),
   'lte': Result(actual_value=0.5517603129029134, judgement=0, m=15414, n=15414, num_trials=250),
   'q99': Result(actual_value=-2.0, judgement=0, m=15414, n=15414, num_trials=250),
   'q99_sa': Result(actual_value=-2.0, judgement=0, m=15414, n=15414, num_trials=575000)}),
 (2,
  {'mean': Result(actual_value=0.062112112112112115, judgement=0, m=20000, n=20000, num_trials=250),
   'lte': Result(actual_value=0.6483222175000001, judgement=0, m=20000, n=20000, num_trials=250),
   'q99': Result(actual_value=5.0, judgement=0, m=20000, n=20000, num_trials=1000),
   'q99_sa': Result(actual_value=5.0, judgement=0, m=20000, n=20000, num_trials=250)}),
 (3,
  {'mean': Result(actual_value=-0.053953953953953956, judgement=0, m=20000, n=20000, num_trials=250),
   'lte': Result(actual_value=0.63775841, judgement=0, m=20000, n=20000, num_trials=250),
   'q99': Result(actual_value=4.0, judgement=0, m=20000, n=20000, num_trials=250),
   'q99_sa': Result(actual_value=4.0, judgement=0, m=20000, n=20000, num_trials=250)})]
```

TESTED=existing tests, ran the notebook for clang 7 and gcc 8.3.