### PR TITLE
umash: use NH instead of PH for 9-16 byte inputs

### DIFF
--- a/smhasher/0001-Hook-UMASH-in-demerphq-s-SMHasher.patch
+++ b/smhasher/0001-Hook-UMASH-in-demerphq-s-SMHasher.patch
@@ -66,16 +66,16 @@ index 7d887a1..aa6ba35 100644
 +
 +  { "umash128", "umash 128",
 +    64, 8 * sizeof(struct umash_params), 128,
-+    0x7AEAB469, umash_state_from_seed, umash128_with_state },
++    0x5D435ED1, umash_state_from_seed, umash128_with_state },
 +  { "umash64", "umash 64",
 +    64, 8 * sizeof(struct umash_params), 64,
-+    0x78350DAF, umash_state_from_seed, umash_with_state },
++    0x286B34EC, umash_state_from_seed, umash_with_state },
 +  { "umash32", "umash 32",
 +    64, 8 * sizeof(struct umash_params), 32,
-+    0x03DA9E97, umash_state_from_seed, umash32_with_state },
++    0x3612CECF, umash_state_from_seed, umash32_with_state },
 +  { "umash32_hi", "umash 32 hi",
 +    64, 8 * sizeof(struct umash_params), 32,
-+    0xFA8E4264, umash_state_from_seed, umash32_hi_with_state },
++    0x8C72DB99, umash_state_from_seed, umash32_hi_with_state },
  };
  int g_hashes_sizeof= sizeof(g_hashes);
  

--- a/smhasher/demerphq-umash128.log
+++ b/smhasher/demerphq-umash128.log
@@ -5,7 +5,7 @@ ok 1 - Found Hash # umash128
 ### seedbits: 64 statebits: 2560 hashbits: 128
 ###################################################################
 ok 2 - Verification code # umash128
-# umash128             - Verification value 0x7AEAB469 : Passed.
+# umash128             - Verification value 0x5D435ED1 : Passed.
 ### Sanity Tests ###
 # Sanity check simple key bit flips and consistency - hashbytes=16..........
 ok 3 - SanityTest # umash128
@@ -14,85 +14,85 @@ ok 4 - Appended Zeroes Test # umash128
 ok 5 - Sanity Test # umash128
 ### Speed Tests ###
 ## Bulk speed test - 262144-byte keys
-# Alignment  7 -  3.115 bytes/cycle - 8912.77 MiB/sec @ 3 ghz
-# Alignment  6 -  2.964 bytes/cycle - 8480.07 MiB/sec @ 3 ghz
-# Alignment  5 -  3.052 bytes/cycle - 8730.47 MiB/sec @ 3 ghz
-# Alignment  4 -  3.000 bytes/cycle - 8582.12 MiB/sec @ 3 ghz
-# Alignment  3 -  2.992 bytes/cycle - 8560.94 MiB/sec @ 3 ghz
-# Alignment  2 -  3.177 bytes/cycle - 9088.71 MiB/sec @ 3 ghz
-# Alignment  1 -  3.157 bytes/cycle - 9032.90 MiB/sec @ 3 ghz
-# Alignment  0 -  3.116 bytes/cycle - 8916.29 MiB/sec @ 3 ghz
-# Average      -  3.072 bytes/cycle - 8788.04 MiB/sec @ 3 ghz
+# Alignment  7 -  4.313 bytes/cycle - 12338.72 MiB/sec @ 3 ghz
+# Alignment  6 -  3.305 bytes/cycle - 9454.56 MiB/sec @ 3 ghz
+# Alignment  5 -  2.971 bytes/cycle - 8499.03 MiB/sec @ 3 ghz
+# Alignment  4 -  2.788 bytes/cycle - 7976.40 MiB/sec @ 3 ghz
+# Alignment  3 -  2.249 bytes/cycle - 6433.93 MiB/sec @ 3 ghz
+# Alignment  2 -  2.996 bytes/cycle - 8570.91 MiB/sec @ 3 ghz
+# Alignment  1 -  2.716 bytes/cycle - 7771.87 MiB/sec @ 3 ghz
+# Alignment  0 -  3.056 bytes/cycle - 8742.39 MiB/sec @ 3 ghz
+# Average      -  3.049 bytes/cycle - 8723.48 MiB/sec @ 3 ghz
 ## KeySpeed tests
-# umash128                  0 byte keys       27.011 c/h
-# umash128                  1 byte keys       29.932 c/h       29.932 c/b        0.033 b/c
-# umash128                  2 byte keys       26.805 c/h       13.403 c/b        0.075 b/c
-# umash128                  3 byte keys       31.119 c/h       10.373 c/b        0.096 b/c
-# umash128                  4 byte keys       27.733 c/h        6.933 c/b        0.144 b/c
-# umash128                  5 byte keys       27.001 c/h        5.400 c/b        0.185 b/c
-# umash128                  6 byte keys       24.999 c/h        4.167 c/b        0.240 b/c
-# umash128                  7 byte keys       24.860 c/h        3.551 c/b        0.282 b/c
-# umash128                  8 byte keys       28.914 c/h        3.614 c/b        0.277 b/c
-# umash128                  9 byte keys       47.027 c/h        5.225 c/b        0.191 b/c
-# umash128                 10 byte keys       46.842 c/h        4.684 c/b        0.213 b/c
-# umash128                 11 byte keys       45.384 c/h        4.126 c/b        0.242 b/c
-# umash128                 12 byte keys       46.985 c/h        3.915 c/b        0.255 b/c
-# umash128                 13 byte keys       48.945 c/h        3.765 c/b        0.266 b/c
-# umash128                 14 byte keys       43.000 c/h        3.071 c/b        0.326 b/c
-# umash128                 15 byte keys       45.607 c/h        3.040 c/b        0.329 b/c
-# umash128                 16 byte keys       39.599 c/h        2.475 c/b        0.404 b/c
-# umash128                 17 byte keys       58.902 c/h        3.465 c/b        0.289 b/c
-# umash128                 18 byte keys       60.903 c/h        3.384 c/b        0.296 b/c
-# umash128                 19 byte keys       59.850 c/h        3.150 c/b        0.317 b/c
-# umash128                 20 byte keys       66.093 c/h        3.305 c/b        0.303 b/c
-# umash128                 21 byte keys       62.770 c/h        2.989 c/b        0.335 b/c
-# umash128                 22 byte keys       58.042 c/h        2.638 c/b        0.379 b/c
-# umash128                 23 byte keys       60.919 c/h        2.649 c/b        0.378 b/c
-# umash128                 24 byte keys       63.417 c/h        2.642 c/b        0.378 b/c
-# umash128                 25 byte keys       66.537 c/h        2.661 c/b        0.376 b/c
-# umash128                 26 byte keys       64.576 c/h        2.484 c/b        0.403 b/c
-# umash128                 27 byte keys       63.154 c/h        2.339 c/b        0.428 b/c
-# umash128                 28 byte keys       59.290 c/h        2.117 c/b        0.472 b/c
-# umash128                 29 byte keys       61.206 c/h        2.111 c/b        0.474 b/c
-# umash128                 30 byte keys       64.459 c/h        2.149 c/b        0.465 b/c
-# umash128                 31 byte keys       64.874 c/h        2.093 c/b        0.478 b/c
-#                          Average < 32       48.336 c/h        3.118 c/b        0.321 b/c
-# umash128                 32 byte keys       61.321 c/h        1.916 c/b        0.522 b/c
-# umash128                 36 byte keys       74.283 c/h        2.063 c/b        0.485 b/c
-# umash128                 40 byte keys       69.241 c/h        1.731 c/b        0.578 b/c
-# umash128                 44 byte keys       66.293 c/h        1.507 c/b        0.664 b/c
-# umash128                 48 byte keys       65.960 c/h        1.374 c/b        0.728 b/c
-# umash128                 52 byte keys       68.795 c/h        1.323 c/b        0.756 b/c
-# umash128                 56 byte keys       85.502 c/h        1.527 c/b        0.655 b/c
-# umash128                 60 byte keys       71.123 c/h        1.185 c/b        0.844 b/c
-# umash128                 64 byte keys       79.422 c/h        1.241 c/b        0.806 b/c
-# umash128                 68 byte keys       54.000 c/h        0.794 c/b        1.259 b/c
-# umash128                 72 byte keys       77.240 c/h        1.073 c/b        0.932 b/c
-# umash128                 76 byte keys       81.183 c/h        1.068 c/b        0.936 b/c
-# umash128                 80 byte keys       66.997 c/h        0.837 c/b        1.194 b/c
-# umash128                 84 byte keys       79.657 c/h        0.948 c/b        1.055 b/c
-# umash128                 88 byte keys       69.656 c/h        0.792 c/b        1.263 b/c
-# umash128                 92 byte keys       52.750 c/h        0.573 c/b        1.744 b/c
-# umash128                 96 byte keys       66.005 c/h        0.688 c/b        1.454 b/c
-# umash128                100 byte keys       79.922 c/h        0.799 c/b        1.251 b/c
-# umash128                104 byte keys       77.205 c/h        0.742 c/b        1.347 b/c
-# umash128                108 byte keys       71.636 c/h        0.663 c/b        1.508 b/c
-# umash128                112 byte keys       85.600 c/h        0.764 c/b        1.308 b/c
-# umash128                116 byte keys       76.804 c/h        0.662 c/b        1.510 b/c
-# umash128                120 byte keys       74.530 c/h        0.621 c/b        1.610 b/c
-# umash128                124 byte keys       72.001 c/h        0.581 c/b        1.722 b/c
-#                         Average < 128       58.462 c/h        1.383 c/b        0.723 b/c
-# umash128                128 byte keys       80.130 c/h        0.626 c/b        1.597 b/c
-# umash128                256 byte keys       82.426 c/h        0.322 c/b        3.106 b/c
-# umash128                512 byte keys      155.054 c/h        0.303 c/b        3.302 b/c
-# umash128               1024 byte keys      480.009 c/h        0.469 c/b        2.133 b/c
-# umash128               2048 byte keys      780.552 c/h        0.381 c/b        2.624 b/c
-# umash128               4096 byte keys     1293.866 c/h        0.316 c/b        3.166 b/c
-# umash128               8192 byte keys     2727.785 c/h        0.333 c/b        3.003 b/c
-# umash128              16384 byte keys     5430.388 c/h        0.331 c/b        3.017 b/c
-# umash128              32768 byte keys    11251.424 c/h        0.343 c/b        2.912 b/c
-# umash128              65536 byte keys    21192.918 c/h        0.323 c/b        3.092 b/c
-#                       Overall Average      708.310 c/h        0.351 c/b        2.852 b/c
+# umash128                  0 byte keys       29.782 c/h
+# umash128                  1 byte keys       36.566 c/h       36.566 c/b        0.027 b/c
+# umash128                  2 byte keys       23.875 c/h       11.938 c/b        0.084 b/c
+# umash128                  3 byte keys       24.117 c/h        8.039 c/b        0.124 b/c
+# umash128                  4 byte keys       20.097 c/h        5.024 c/b        0.199 b/c
+# umash128                  5 byte keys       21.742 c/h        4.348 c/b        0.230 b/c
+# umash128                  6 byte keys       24.979 c/h        4.163 c/b        0.240 b/c
+# umash128                  7 byte keys       24.086 c/h        3.441 c/b        0.291 b/c
+# umash128                  8 byte keys       22.532 c/h        2.816 c/b        0.355 b/c
+# umash128                  9 byte keys       47.930 c/h        5.326 c/b        0.188 b/c
+# umash128                 10 byte keys       50.130 c/h        5.013 c/b        0.199 b/c
+# umash128                 11 byte keys       46.447 c/h        4.222 c/b        0.237 b/c
+# umash128                 12 byte keys       44.271 c/h        3.689 c/b        0.271 b/c
+# umash128                 13 byte keys       40.964 c/h        3.151 c/b        0.317 b/c
+# umash128                 14 byte keys       40.778 c/h        2.913 c/b        0.343 b/c
+# umash128                 15 byte keys       44.806 c/h        2.987 c/b        0.335 b/c
+# umash128                 16 byte keys       33.645 c/h        2.103 c/b        0.476 b/c
+# umash128                 17 byte keys       59.167 c/h        3.480 c/b        0.287 b/c
+# umash128                 18 byte keys       57.111 c/h        3.173 c/b        0.315 b/c
+# umash128                 19 byte keys       68.370 c/h        3.598 c/b        0.278 b/c
+# umash128                 20 byte keys       66.085 c/h        3.304 c/b        0.303 b/c
+# umash128                 21 byte keys       64.419 c/h        3.068 c/b        0.326 b/c
+# umash128                 22 byte keys       58.386 c/h        2.654 c/b        0.377 b/c
+# umash128                 23 byte keys       65.678 c/h        2.856 c/b        0.350 b/c
+# umash128                 24 byte keys       67.200 c/h        2.800 c/b        0.357 b/c
+# umash128                 25 byte keys       69.075 c/h        2.763 c/b        0.362 b/c
+# umash128                 26 byte keys       64.484 c/h        2.480 c/b        0.403 b/c
+# umash128                 27 byte keys       56.041 c/h        2.076 c/b        0.482 b/c
+# umash128                 28 byte keys       54.319 c/h        1.940 c/b        0.515 b/c
+# umash128                 29 byte keys       48.712 c/h        1.680 c/b        0.595 b/c
+# umash128                 30 byte keys       53.380 c/h        1.779 c/b        0.562 b/c
+# umash128                 31 byte keys       52.481 c/h        1.693 c/b        0.591 b/c
+#                          Average < 32       46.302 c/h        2.987 c/b        0.335 b/c
+# umash128                 32 byte keys       52.381 c/h        1.637 c/b        0.611 b/c
+# umash128                 36 byte keys       53.193 c/h        1.478 c/b        0.677 b/c
+# umash128                 40 byte keys       70.232 c/h        1.756 c/b        0.570 b/c
+# umash128                 44 byte keys       73.161 c/h        1.663 c/b        0.601 b/c
+# umash128                 48 byte keys       64.830 c/h        1.351 c/b        0.740 b/c
+# umash128                 52 byte keys       71.417 c/h        1.373 c/b        0.728 b/c
+# umash128                 56 byte keys       62.418 c/h        1.115 c/b        0.897 b/c
+# umash128                 60 byte keys       67.695 c/h        1.128 c/b        0.886 b/c
+# umash128                 64 byte keys       75.203 c/h        1.175 c/b        0.851 b/c
+# umash128                 68 byte keys       77.050 c/h        1.133 c/b        0.883 b/c
+# umash128                 72 byte keys       79.627 c/h        1.106 c/b        0.904 b/c
+# umash128                 76 byte keys       78.348 c/h        1.031 c/b        0.970 b/c
+# umash128                 80 byte keys       81.736 c/h        1.022 c/b        0.979 b/c
+# umash128                 84 byte keys       86.986 c/h        1.036 c/b        0.966 b/c
+# umash128                 88 byte keys       88.135 c/h        1.002 c/b        0.998 b/c
+# umash128                 92 byte keys       80.185 c/h        0.872 c/b        1.147 b/c
+# umash128                 96 byte keys       82.687 c/h        0.861 c/b        1.161 b/c
+# umash128                100 byte keys       88.779 c/h        0.888 c/b        1.126 b/c
+# umash128                104 byte keys       89.605 c/h        0.862 c/b        1.161 b/c
+# umash128                108 byte keys       91.771 c/h        0.850 c/b        1.177 b/c
+# umash128                112 byte keys       95.753 c/h        0.855 c/b        1.170 b/c
+# umash128                116 byte keys       97.491 c/h        0.840 c/b        1.190 b/c
+# umash128                120 byte keys       98.236 c/h        0.819 c/b        1.222 b/c
+# umash128                124 byte keys       55.000 c/h        0.444 c/b        2.255 b/c
+#                         Average < 128       59.707 c/h        1.412 c/b        0.708 b/c
+# umash128                128 byte keys       55.000 c/h        0.430 c/b        2.327 b/c
+# umash128                256 byte keys       84.436 c/h        0.330 c/b        3.032 b/c
+# umash128                512 byte keys      156.635 c/h        0.306 c/b        3.269 b/c
+# umash128               1024 byte keys      262.500 c/h        0.256 c/b        3.901 b/c
+# umash128               2048 byte keys      480.223 c/h        0.234 c/b        4.265 b/c
+# umash128               4096 byte keys     1197.909 c/h        0.292 c/b        3.419 b/c
+# umash128               8192 byte keys     2434.508 c/h        0.297 c/b        3.365 b/c
+# umash128              16384 byte keys     5693.034 c/h        0.347 c/b        2.878 b/c
+# umash128              32768 byte keys    10876.222 c/h        0.332 c/b        3.013 b/c
+# umash128              65536 byte keys    22050.267 c/h        0.336 c/b        2.972 b/c
+#                       Overall Average      706.580 c/h        0.350 c/b        2.859 b/c
 ok 6 - Speed (always passes) # umash128
 ### Differential Tests ###
 # Testing 8303632 up-to-5-bit differentials in 64-bit keys -> 128 bit hashes.
@@ -8712,21 +8712,21 @@ ok 152 - Strict Avalanche Criteria - 48 bit/6 byte keys # umash128
 ok 153 - Strict Avalanche Criteria - 56 bit/7 byte keys # umash128
 # Testing  64-bit keys.......... ok.     # worst-bit:   0.678% error-ratio: 9.937791e-01
 ok 154 - Strict Avalanche Criteria - 64 bit/8 byte keys # umash128
-# Testing  72-bit keys.......... ok.     # worst-bit:   0.649% error-ratio: 1.013919e+00
+# Testing  72-bit keys.......... ok.     # worst-bit:   0.652% error-ratio: 1.012313e+00
 ok 155 - Strict Avalanche Criteria - 72 bit/9 byte keys # umash128
-# Testing  80-bit keys.......... ok.     # worst-bit:   0.640% error-ratio: 9.697180e-01
+# Testing  80-bit keys.......... ok.     # worst-bit:   0.687% error-ratio: 1.014311e+00
 ok 156 - Strict Avalanche Criteria - 80 bit/10 byte keys # umash128
-# Testing  88-bit keys.......... ok.     # worst-bit:   0.653% error-ratio: 1.007849e+00
+# Testing  88-bit keys.......... ok.     # worst-bit:   0.650% error-ratio: 9.989631e-01
 ok 157 - Strict Avalanche Criteria - 88 bit/11 byte keys # umash128
-# Testing  96-bit keys.......... ok.     # worst-bit:   0.616% error-ratio: 9.912113e-01
+# Testing  96-bit keys.......... ok.     # worst-bit:   0.596% error-ratio: 1.005563e+00
 ok 158 - Strict Avalanche Criteria - 96 bit/12 byte keys # umash128
-# Testing 104-bit keys.......... ok.     # worst-bit:   0.702% error-ratio: 9.835328e-01
+# Testing 104-bit keys.......... ok.     # worst-bit:   0.626% error-ratio: 9.954333e-01
 ok 159 - Strict Avalanche Criteria - 104 bit/13 byte keys # umash128
-# Testing 112-bit keys.......... ok.     # worst-bit:   0.700% error-ratio: 9.922487e-01
+# Testing 112-bit keys.......... ok.     # worst-bit:   0.615% error-ratio: 9.967902e-01
 ok 160 - Strict Avalanche Criteria - 112 bit/14 byte keys # umash128
-# Testing 120-bit keys.......... ok.     # worst-bit:   0.683% error-ratio: 9.957499e-01
+# Testing 120-bit keys.......... ok.     # worst-bit:   0.626% error-ratio: 1.000884e+00
 ok 161 - Strict Avalanche Criteria - 120 bit/15 byte keys # umash128
-# Testing 128-bit keys.......... ok.     # worst-bit:   0.750% error-ratio: 1.002386e+00
+# Testing 128-bit keys.......... ok.     # worst-bit:   0.633% error-ratio: 1.005925e+00
 ok 162 - Strict Avalanche Criteria - 128 bit/16 byte keys # umash128
 # Testing 136-bit keys.......... ok.     # worst-bit:   0.631% error-ratio: 1.020024e+00
 ok 163 - Strict Avalanche Criteria - 136 bit/17 byte keys # umash128
@@ -17005,7 +17005,7 @@ ok 172 - Strict Avalanche Criteria - 2048 bit/256 byte keys # umash128
 ----------------------------------------------------------------------------------------------------
 (126,127) - ........................................................................................
 ----------------------------------------------------------------------------------------------------
-# Max bias 0.006290 - ( 69 :  60,123)
+# Max bias 0.007114 - ( 76 :  47, 66)
 ok 173 - Bit Independence Criteria (BicTest3) # umash128
 ### Keyset 'Cyclic' Tests ###
 # Keyset 'Cyclic' - 8 cycles of 16 bytes - 10000000 keys
@@ -18093,5 +18093,5 @@ ok 839 - Distribution Bias Check for Keyset 'Words'
 ok 840 - all tests passed # umash128
 1..840
 # All Tests Passed. umash128 passed all 840 tests run.
-# Testing took 24608.557273 seconds
-# This is SMHasher version v1.3-demerphq-43-g0762887-dirty - built on Sep 19 2020.
+# Testing took 17963.751944 seconds
+# This is SMHasher version v1.3-demerphq-43-g0762887-dirty - built on Sep 22 2020.

--- a/smhasher/demerphq-umash32.log
+++ b/smhasher/demerphq-umash32.log
@@ -5,7 +5,7 @@ ok 1 - Found Hash # umash32
 ### seedbits: 64 statebits: 2560 hashbits: 32
 ###################################################################
 ok 2 - Verification code # umash32
-# umash32              - Verification value 0x03DA9E97 : Passed.
+# umash32              - Verification value 0x3612CECF : Passed.
 ### Sanity Tests ###
 # Sanity check simple key bit flips and consistency - hashbytes=4..........
 ok 3 - SanityTest # umash32
@@ -14,85 +14,85 @@ ok 4 - Appended Zeroes Test # umash32
 ok 5 - Sanity Test # umash32
 ### Speed Tests ###
 ## Bulk speed test - 262144-byte keys
-# Alignment  7 -  5.531 bytes/cycle - 15824.44 MiB/sec @ 3 ghz
-# Alignment  6 -  7.055 bytes/cycle - 20183.53 MiB/sec @ 3 ghz
-# Alignment  5 -  5.587 bytes/cycle - 15983.58 MiB/sec @ 3 ghz
-# Alignment  4 -  5.320 bytes/cycle - 15220.67 MiB/sec @ 3 ghz
-# Alignment  3 -  5.601 bytes/cycle - 16024.58 MiB/sec @ 3 ghz
-# Alignment  2 -  6.135 bytes/cycle - 17551.55 MiB/sec @ 3 ghz
-# Alignment  1 -  5.642 bytes/cycle - 16140.78 MiB/sec @ 3 ghz
-# Alignment  0 -  6.287 bytes/cycle - 17986.50 MiB/sec @ 3 ghz
-# Average      -  5.895 bytes/cycle - 16864.45 MiB/sec @ 3 ghz
+# Alignment  7 -  7.106 bytes/cycle - 20331.11 MiB/sec @ 3 ghz
+# Alignment  6 -  6.592 bytes/cycle - 18859.45 MiB/sec @ 3 ghz
+# Alignment  5 -  6.631 bytes/cycle - 18972.74 MiB/sec @ 3 ghz
+# Alignment  4 -  6.949 bytes/cycle - 19880.12 MiB/sec @ 3 ghz
+# Alignment  3 -  6.646 bytes/cycle - 19014.85 MiB/sec @ 3 ghz
+# Alignment  2 -  6.377 bytes/cycle - 18245.43 MiB/sec @ 3 ghz
+# Alignment  1 -  6.543 bytes/cycle - 18720.31 MiB/sec @ 3 ghz
+# Alignment  0 -  6.412 bytes/cycle - 18346.23 MiB/sec @ 3 ghz
+# Average      -  6.657 bytes/cycle - 19046.28 MiB/sec @ 3 ghz
 ## KeySpeed tests
-# umash32                   0 byte keys       19.000 c/h
-# umash32                   1 byte keys       23.384 c/h       23.384 c/b        0.043 b/c
-# umash32                   2 byte keys       18.000 c/h        9.000 c/b        0.111 b/c
-# umash32                   3 byte keys       28.080 c/h        9.360 c/b        0.107 b/c
-# umash32                   4 byte keys       26.952 c/h        6.738 c/b        0.148 b/c
-# umash32                   5 byte keys       34.444 c/h        6.889 c/b        0.145 b/c
-# umash32                   6 byte keys       40.562 c/h        6.760 c/b        0.148 b/c
-# umash32                   7 byte keys       41.801 c/h        5.972 c/b        0.167 b/c
-# umash32                   8 byte keys       38.480 c/h        4.810 c/b        0.208 b/c
-# umash32                   9 byte keys       42.333 c/h        4.704 c/b        0.213 b/c
-# umash32                  10 byte keys       42.180 c/h        4.218 c/b        0.237 b/c
-# umash32                  11 byte keys       44.858 c/h        4.078 c/b        0.245 b/c
-# umash32                  12 byte keys       44.281 c/h        3.690 c/b        0.271 b/c
-# umash32                  13 byte keys       47.408 c/h        3.647 c/b        0.274 b/c
-# umash32                  14 byte keys       46.214 c/h        3.301 c/b        0.303 b/c
-# umash32                  15 byte keys       45.576 c/h        3.038 c/b        0.329 b/c
-# umash32                  16 byte keys       46.419 c/h        2.901 c/b        0.345 b/c
-# umash32                  17 byte keys       57.186 c/h        3.364 c/b        0.297 b/c
-# umash32                  18 byte keys       54.538 c/h        3.030 c/b        0.330 b/c
-# umash32                  19 byte keys       48.320 c/h        2.543 c/b        0.393 b/c
-# umash32                  20 byte keys       54.155 c/h        2.708 c/b        0.369 b/c
-# umash32                  21 byte keys       42.000 c/h        2.000 c/b        0.500 b/c
-# umash32                  22 byte keys       47.304 c/h        2.150 c/b        0.465 b/c
-# umash32                  23 byte keys       48.745 c/h        2.119 c/b        0.472 b/c
-# umash32                  24 byte keys       53.215 c/h        2.217 c/b        0.451 b/c
-# umash32                  25 byte keys       47.473 c/h        1.899 c/b        0.527 b/c
-# umash32                  26 byte keys       47.481 c/h        1.826 c/b        0.548 b/c
-# umash32                  27 byte keys       48.358 c/h        1.791 c/b        0.558 b/c
-# umash32                  28 byte keys       42.000 c/h        1.500 c/b        0.667 b/c
-# umash32                  29 byte keys       48.341 c/h        1.667 c/b        0.600 b/c
-# umash32                  30 byte keys       47.029 c/h        1.568 c/b        0.638 b/c
-# umash32                  31 byte keys       40.000 c/h        1.290 c/b        0.775 b/c
-#                          Average < 32       42.379 c/h        2.734 c/b        0.366 b/c
-# umash32                  32 byte keys       47.848 c/h        1.495 c/b        0.669 b/c
-# umash32                  36 byte keys       49.606 c/h        1.378 c/b        0.726 b/c
-# umash32                  40 byte keys       50.622 c/h        1.266 c/b        0.790 b/c
-# umash32                  44 byte keys       49.861 c/h        1.133 c/b        0.882 b/c
-# umash32                  48 byte keys       49.328 c/h        1.028 c/b        0.973 b/c
-# umash32                  52 byte keys       49.614 c/h        0.954 c/b        1.048 b/c
-# umash32                  56 byte keys       50.994 c/h        0.911 c/b        1.098 b/c
-# umash32                  60 byte keys       49.545 c/h        0.826 c/b        1.211 b/c
-# umash32                  64 byte keys       48.481 c/h        0.758 c/b        1.320 b/c
-# umash32                  68 byte keys       52.700 c/h        0.775 c/b        1.290 b/c
-# umash32                  72 byte keys       52.932 c/h        0.735 c/b        1.360 b/c
-# umash32                  76 byte keys       56.697 c/h        0.746 c/b        1.340 b/c
-# umash32                  80 byte keys       62.920 c/h        0.786 c/b        1.271 b/c
-# umash32                  84 byte keys       54.094 c/h        0.644 c/b        1.553 b/c
-# umash32                  88 byte keys       52.985 c/h        0.602 c/b        1.661 b/c
-# umash32                  92 byte keys       59.352 c/h        0.645 c/b        1.550 b/c
-# umash32                  96 byte keys       44.493 c/h        0.463 c/b        2.158 b/c
-# umash32                 100 byte keys       59.992 c/h        0.600 c/b        1.667 b/c
-# umash32                 104 byte keys       44.000 c/h        0.423 c/b        2.364 b/c
-# umash32                 108 byte keys       59.009 c/h        0.546 c/b        1.830 b/c
-# umash32                 112 byte keys       57.205 c/h        0.511 c/b        1.958 b/c
-# umash32                 116 byte keys       57.809 c/h        0.498 c/b        2.007 b/c
-# umash32                 120 byte keys       56.467 c/h        0.471 c/b        2.125 b/c
-# umash32                 124 byte keys       65.422 c/h        0.528 c/b        1.895 b/c
-#                         Average < 128       47.109 c/h        1.114 c/b        0.898 b/c
-# umash32                 128 byte keys       70.659 c/h        0.552 c/b        1.812 b/c
-# umash32                 256 byte keys      120.369 c/h        0.470 c/b        2.127 b/c
-# umash32                 512 byte keys      103.389 c/h        0.202 c/b        4.952 b/c
-# umash32                1024 byte keys      155.535 c/h        0.152 c/b        6.584 b/c
-# umash32                2048 byte keys      381.478 c/h        0.186 c/b        5.369 b/c
-# umash32                4096 byte keys      615.196 c/h        0.150 c/b        6.658 b/c
-# umash32                8192 byte keys     1233.511 c/h        0.151 c/b        6.641 b/c
-# umash32               16384 byte keys     1770.436 c/h        0.108 c/b        9.254 b/c
-# umash32               32768 byte keys     3570.403 c/h        0.109 c/b        9.178 b/c
-# umash32               65536 byte keys     9715.264 c/h        0.148 c/b        6.746 b/c
-#                       Overall Average      308.702 c/h        0.153 c/b        6.543 b/c
+# umash32                   0 byte keys       34.113 c/h
+# umash32                   1 byte keys       29.020 c/h       29.020 c/b        0.034 b/c
+# umash32                   2 byte keys       29.341 c/h       14.670 c/b        0.068 b/c
+# umash32                   3 byte keys       29.176 c/h        9.725 c/b        0.103 b/c
+# umash32                   4 byte keys       32.633 c/h        8.158 c/b        0.123 b/c
+# umash32                   5 byte keys       31.161 c/h        6.232 c/b        0.160 b/c
+# umash32                   6 byte keys       29.773 c/h        4.962 c/b        0.202 b/c
+# umash32                   7 byte keys       29.018 c/h        4.145 c/b        0.241 b/c
+# umash32                   8 byte keys       29.162 c/h        3.645 c/b        0.274 b/c
+# umash32                   9 byte keys       36.959 c/h        4.107 c/b        0.244 b/c
+# umash32                  10 byte keys       37.334 c/h        3.733 c/b        0.268 b/c
+# umash32                  11 byte keys       37.421 c/h        3.402 c/b        0.294 b/c
+# umash32                  12 byte keys       38.200 c/h        3.183 c/b        0.314 b/c
+# umash32                  13 byte keys       37.731 c/h        2.902 c/b        0.345 b/c
+# umash32                  14 byte keys       39.689 c/h        2.835 c/b        0.353 b/c
+# umash32                  15 byte keys       37.680 c/h        2.512 c/b        0.398 b/c
+# umash32                  16 byte keys       38.793 c/h        2.425 c/b        0.412 b/c
+# umash32                  17 byte keys       42.228 c/h        2.484 c/b        0.403 b/c
+# umash32                  18 byte keys       45.759 c/h        2.542 c/b        0.393 b/c
+# umash32                  19 byte keys       45.369 c/h        2.388 c/b        0.419 b/c
+# umash32                  20 byte keys       42.359 c/h        2.118 c/b        0.472 b/c
+# umash32                  21 byte keys       43.227 c/h        2.058 c/b        0.486 b/c
+# umash32                  22 byte keys       45.906 c/h        2.087 c/b        0.479 b/c
+# umash32                  23 byte keys       44.310 c/h        1.927 c/b        0.519 b/c
+# umash32                  24 byte keys       46.147 c/h        1.923 c/b        0.520 b/c
+# umash32                  25 byte keys       43.479 c/h        1.739 c/b        0.575 b/c
+# umash32                  26 byte keys       44.958 c/h        1.729 c/b        0.578 b/c
+# umash32                  27 byte keys       42.230 c/h        1.564 c/b        0.639 b/c
+# umash32                  28 byte keys       42.332 c/h        1.512 c/b        0.661 b/c
+# umash32                  29 byte keys       42.406 c/h        1.462 c/b        0.684 b/c
+# umash32                  30 byte keys       42.519 c/h        1.417 c/b        0.706 b/c
+# umash32                  31 byte keys       43.137 c/h        1.392 c/b        0.719 b/c
+#                          Average < 32       38.549 c/h        2.487 c/b        0.402 b/c
+# umash32                  32 byte keys       46.672 c/h        1.458 c/b        0.686 b/c
+# umash32                  36 byte keys       47.043 c/h        1.307 c/b        0.765 b/c
+# umash32                  40 byte keys       47.974 c/h        1.199 c/b        0.834 b/c
+# umash32                  44 byte keys       50.189 c/h        1.141 c/b        0.877 b/c
+# umash32                  48 byte keys       48.905 c/h        1.019 c/b        0.982 b/c
+# umash32                  52 byte keys       50.160 c/h        0.965 c/b        1.037 b/c
+# umash32                  56 byte keys       51.548 c/h        0.921 c/b        1.086 b/c
+# umash32                  60 byte keys       51.837 c/h        0.864 c/b        1.157 b/c
+# umash32                  64 byte keys       44.156 c/h        0.690 c/b        1.449 b/c
+# umash32                  68 byte keys       44.090 c/h        0.648 c/b        1.542 b/c
+# umash32                  72 byte keys       42.990 c/h        0.597 c/b        1.675 b/c
+# umash32                  76 byte keys       40.000 c/h        0.526 c/b        1.900 b/c
+# umash32                  80 byte keys       40.000 c/h        0.500 c/b        2.000 b/c
+# umash32                  84 byte keys       45.078 c/h        0.537 c/b        1.863 b/c
+# umash32                  88 byte keys       45.123 c/h        0.513 c/b        1.950 b/c
+# umash32                  92 byte keys       47.376 c/h        0.515 c/b        1.942 b/c
+# umash32                  96 byte keys       43.836 c/h        0.457 c/b        2.190 b/c
+# umash32                 100 byte keys       48.791 c/h        0.488 c/b        2.050 b/c
+# umash32                 104 byte keys       57.127 c/h        0.549 c/b        1.821 b/c
+# umash32                 108 byte keys       60.744 c/h        0.562 c/b        1.778 b/c
+# umash32                 112 byte keys       56.676 c/h        0.506 c/b        1.976 b/c
+# umash32                 116 byte keys       61.507 c/h        0.530 c/b        1.886 b/c
+# umash32                 120 byte keys       62.482 c/h        0.521 c/b        1.921 b/c
+# umash32                 124 byte keys       63.928 c/h        0.516 c/b        1.940 b/c
+#                         Average < 128       43.425 c/h        1.027 c/b        0.974 b/c
+# umash32                 128 byte keys       62.514 c/h        0.488 c/b        2.048 b/c
+# umash32                 256 byte keys      101.518 c/h        0.397 c/b        2.522 b/c
+# umash32                 512 byte keys      162.604 c/h        0.318 c/b        3.149 b/c
+# umash32                1024 byte keys      238.941 c/h        0.233 c/b        4.286 b/c
+# umash32                2048 byte keys      395.274 c/h        0.193 c/b        5.181 b/c
+# umash32                4096 byte keys      668.148 c/h        0.163 c/b        6.130 b/c
+# umash32                8192 byte keys     1234.638 c/h        0.151 c/b        6.635 b/c
+# umash32               16384 byte keys     2443.637 c/h        0.149 c/b        6.705 b/c
+# umash32               32768 byte keys     3256.009 c/h        0.099 c/b       10.064 b/c
+# umash32               65536 byte keys     9125.504 c/h        0.139 c/b        7.182 b/c
+#                       Overall Average      304.857 c/h        0.151 c/b        6.626 b/c
 ok 6 - Speed (always passes) # umash32
 ### Differential Tests ###
 # Testing 8303632 up-to-5-bit differentials in 64-bit keys -> 32 bit hashes.
@@ -2568,21 +2568,21 @@ ok 152 - Strict Avalanche Criteria - 48 bit/6 byte keys # umash32
 ok 153 - Strict Avalanche Criteria - 56 bit/7 byte keys # umash32
 # Testing  64-bit keys.......... ok.     # worst-bit:   0.601% error-ratio: 1.014912e+00
 ok 154 - Strict Avalanche Criteria - 64 bit/8 byte keys # umash32
-# Testing  72-bit keys.......... ok.     # worst-bit:   0.587% error-ratio: 9.978377e-01
+# Testing  72-bit keys.......... ok.     # worst-bit:   0.575% error-ratio: 1.008475e+00
 ok 155 - Strict Avalanche Criteria - 72 bit/9 byte keys # umash32
-# Testing  80-bit keys.......... ok.     # worst-bit:   0.528% error-ratio: 9.419811e-01
+# Testing  80-bit keys.......... ok.     # worst-bit:   0.602% error-ratio: 1.001169e+00
 ok 156 - Strict Avalanche Criteria - 80 bit/10 byte keys # umash32
-# Testing  88-bit keys.......... ok.     # worst-bit:   0.608% error-ratio: 9.908014e-01
+# Testing  88-bit keys.......... ok.     # worst-bit:   0.523% error-ratio: 9.674560e-01
 ok 157 - Strict Avalanche Criteria - 88 bit/11 byte keys # umash32
-# Testing  96-bit keys.......... ok.     # worst-bit:   0.584% error-ratio: 9.784649e-01
+# Testing  96-bit keys.......... ok.     # worst-bit:   0.562% error-ratio: 1.009469e+00
 ok 158 - Strict Avalanche Criteria - 96 bit/12 byte keys # umash32
-# Testing 104-bit keys.......... ok.     # worst-bit:   0.625% error-ratio: 9.588266e-01
+# Testing 104-bit keys.......... ok.     # worst-bit:   0.552% error-ratio: 9.931742e-01
 ok 159 - Strict Avalanche Criteria - 104 bit/13 byte keys # umash32
-# Testing 112-bit keys.......... ok.     # worst-bit:   0.582% error-ratio: 9.995448e-01
+# Testing 112-bit keys.......... ok.     # worst-bit:   0.589% error-ratio: 9.933696e-01
 ok 160 - Strict Avalanche Criteria - 112 bit/14 byte keys # umash32
-# Testing 120-bit keys.......... ok.     # worst-bit:   0.567% error-ratio: 9.960943e-01
+# Testing 120-bit keys.......... ok.     # worst-bit:   0.607% error-ratio: 9.658200e-01
 ok 161 - Strict Avalanche Criteria - 120 bit/15 byte keys # umash32
-# Testing 128-bit keys.......... ok.     # worst-bit:   0.750% error-ratio: 1.023986e+00
+# Testing 128-bit keys.......... ok.     # worst-bit:   0.582% error-ratio: 9.872674e-01
 ok 162 - Strict Avalanche Criteria - 128 bit/16 byte keys # umash32
 # Testing 136-bit keys.......... ok.     # worst-bit:   0.579% error-ratio: 1.029165e+00
 ok 163 - Strict Avalanche Criteria - 136 bit/17 byte keys # umash32
@@ -3133,7 +3133,7 @@ ok 172 - Strict Avalanche Criteria - 2048 bit/256 byte keys # umash32
 ----------------------------------------------------------------------------------------------------
 ( 30, 31) - ........................................................................................
 ----------------------------------------------------------------------------------------------------
-# Max bias 0.005866 - ( 65 :  18, 21)
+# Max bias 0.006058 - ( 60 :  14, 21)
 ok 173 - Bit Independence Criteria (BicTest3) # umash32
 ### Keyset 'Cyclic' Tests ###
 # Keyset 'Cyclic' - 8 cycles of 4 bytes - 10000000 keys
@@ -3164,13 +3164,13 @@ ok 186 - Distribution Bias Check for Keyset 'TwoBytes' - up-to-4-byte keys, 6525
 # Testing collisions   - Expected  3484.56, actual     3500 ( 1.00x) - passed
 ok 187 - Collision Rate for Keyset 'TwoBytes' - up-to-8-byte keys, 5471025 total keys
 ok 188 - Distribution Bias Check for Keyset 'TwoBytes' - up-to-8-byte keys, 5471025 total keys
-# Testing collisions   - Expected 40347.77, actual    40162 ( 1.00x) - passed
+# Testing collisions   - Expected 40347.77, actual    40169 ( 1.00x) - passed
 ok 189 - Collision Rate for Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
 ok 190 - Distribution Bias Check for Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
-# Testing collisions   - Expected 227963.15, actual   226937 ( 1.00x) - passed
+# Testing collisions   - Expected 227963.15, actual   227637 ( 1.00x) - passed
 ok 191 - Collision Rate for Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
 ok 192 - Distribution Bias Check for Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
-# Testing collisions   - Expected 871784.70, actual   866685 ( 0.99x) - passed
+# Testing collisions   - Expected 871784.70, actual   867201 ( 0.99x) - passed
 ok 193 - Collision Rate for Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
 ok 194 - Distribution Bias Check for Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
 ok 195 - Keyset 'TwoBytes' # umash32
@@ -3216,7 +3216,7 @@ ok 213 - Distribution Bias Check for Keyset 'Sparse' - 56-bit keys with up to 5 
 ok 214 - Collision Rate for Keyset 'Sparse' - 64-bit keys with up to 5 bits set
 ok 215 - Distribution Bias Check for Keyset 'Sparse' - 64-bit keys with up to 5 bits set
 # Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
-# Testing collisions   - Expected  1401.34, actual     1431 ( 1.02x) - passed
+# Testing collisions   - Expected  1401.34, actual     1424 ( 1.02x) - passed
 ok 216 - Collision Rate for Keyset 'Sparse' - 96-bit keys with up to 4 bits set
 ok 217 - Distribution Bias Check for Keyset 'Sparse' - 96-bit keys with up to 4 bits set
 ok 218 - Keyset 'Sparse' # umash32
@@ -3353,13 +3353,13 @@ ok 277 - Collision Rate for Keyset 'City64-MultiCollision' - seed 9 # umash32
 ok 278 - Collision Rate for Keyset 'City64-MultiCollision' - seed 10 # umash32
 ### Keyset 'Combination Lowbits' Tests ###
 # Keyset 'Combination' - up to 8 blocks from a set of 8 - 19173960 keys
-# Testing collisions   - Expected 42799.01, actual    42767 ( 1.00x) - passed
+# Testing collisions   - Expected 42799.01, actual    42775 ( 1.00x) - passed
 ok 279 - Collision Rate for Keyset 'Combination Lowbits'
 ok 280 - Distribution Bias Check for Keyset 'Combination Lowbits'
 ok 281 - Keyset 'Combination Lowbits' # umash32
 ### Keyset 'Combination Highbits' Tests ###
 # Keyset 'Combination' - up to 8 blocks from a set of 8 - 19173960 keys
-# Testing collisions   - Expected 42799.01, actual    42841 ( 1.00x) - passed
+# Testing collisions   - Expected 42799.01, actual    42829 ( 1.00x) - passed
 ok 282 - Collision Rate for Keyset 'Combination Highbits'
 ok 283 - Distribution Bias Check for Keyset 'Combination Highbits'
 ok 284 - Keyset 'Combination Highbits' # umash32
@@ -3371,7 +3371,7 @@ ok 286 - Distribution Bias Check for Keyset 'Combination Highbits2'
 ok 287 - Keyset 'Combination Highbits2' # umash32
 ### Keyset 'Combination HiBit-Null' Tests ###
 # Keyset 'Combination' - up to 20 blocks from a set of 2 - 2097150 keys
-# Testing collisions   - Expected   512.00, actual      537 ( 1.05x) - passed
+# Testing collisions   - Expected   512.00, actual      536 ( 1.05x) - passed
 ok 288 - Collision Rate for Keyset 'Combination HiBit-Null'
 ok 289 - Distribution Bias Check for Keyset 'Combination HiBit-Null'
 ok 290 - Keyset 'Combination HiBit-Null' # umash32
@@ -3383,7 +3383,7 @@ ok 292 - Distribution Bias Check for Keyset 'Combination LowBit-Null'
 ok 293 - Keyset 'Combination LowBit-Null' # umash32
 ### Keyset 'Combination Hi-Lo' Tests ###
 # Keyset 'Combination' - up to 6 blocks from a set of 15 - 12204240 keys
-# Testing collisions   - Expected 17339.30, actual    17375 ( 1.00x) - passed
+# Testing collisions   - Expected 17339.30, actual    17346 ( 1.00x) - passed
 ok 294 - Collision Rate for Keyset 'Combination Hi-Lo'
 ok 295 - Distribution Bias Check for Keyset 'Combination Hi-Lo'
 ok 296 - Keyset 'Combination Hi-Lo' # umash32
@@ -3587,15 +3587,15 @@ ok 426 - Distribution Bias Check for Window at  64
 ok 427 - Keyset 'Window' # umash32
 ### Keyset 'Text' Tests ###
 # Keyset 'Text' - keys of form "Foo[XXXX]Bar" - 14776336 keys
-# Testing collisions   - Expected 25418.13, actual    25272 ( 0.99x) - passed
+# Testing collisions   - Expected 25418.13, actual    25490 ( 1.00x) - passed
 ok 428 - Collision Rate for Keyset 'Text' - keys of form "Foo[XXXX]Bar" - 14776336 keys
 ok 429 - Distribution Bias Check for Keyset 'Text' - keys of form "Foo[XXXX]Bar" - 14776336 keys
 # Keyset 'Text' - keys of form "FooBar[XXXX]" - 14776336 keys
-# Testing collisions   - Expected 25418.13, actual    25720 ( 1.01x) - passed
+# Testing collisions   - Expected 25418.13, actual    25480 ( 1.00x) - passed
 ok 430 - Collision Rate for Keyset 'Text' - keys of form "FooBar[XXXX]" - 14776336 keys
 ok 431 - Distribution Bias Check for Keyset 'Text' - keys of form "FooBar[XXXX]" - 14776336 keys
 # Keyset 'Text' - keys of form "[XXXX]FooBar" - 14776336 keys
-# Testing collisions   - Expected 25418.13, actual    25710 ( 1.01x) - passed
+# Testing collisions   - Expected 25418.13, actual    25265 ( 0.99x) - passed
 ok 432 - Collision Rate for Keyset 'Text' - keys of form "[XXXX]FooBar" - 14776336 keys
 ok 433 - Distribution Bias Check for Keyset 'Text' - keys of form "[XXXX]FooBar" - 14776336 keys
 ok 434 - Keyset 'Text' # umash32
@@ -3639,11 +3639,11 @@ ok 452 - Distribution Bias Check for Keyset 'Effs' - 262144 keys, nonzero seed
 ok 453 - Keyset 'Effs' # umash32
 ### Keyset 'Words' Tests ###
 # Hashed 501909 keys from 167303 words from file '/usr/share/dict/words'
-# Testing collisions   - Expected    29.33, actual       35 ( 1.19x) - passed
+# Testing collisions   - Expected    29.33, actual       25 ( 0.85x) - passed
 ok 454 - Collision Rate for Keyset 'Words'
 ok 455 - Distribution Bias Check for Keyset 'Words'
 ok 456 - all tests passed # umash32
 1..456
 # All Tests Passed. umash32 passed all 456 tests run.
-# Testing took 4286.037161 seconds
-# This is SMHasher version v1.3-demerphq-43-g0762887-dirty - built on Sep 19 2020.
+# Testing took 4757.861379 seconds
+# This is SMHasher version v1.3-demerphq-43-g0762887-dirty - built on Sep 22 2020.

--- a/smhasher/demerphq-umash32_hi.log
+++ b/smhasher/demerphq-umash32_hi.log
@@ -5,7 +5,7 @@ ok 1 - Found Hash # umash32_hi
 ### seedbits: 64 statebits: 2560 hashbits: 32
 ###################################################################
 ok 2 - Verification code # umash32_hi
-# umash32_hi           - Verification value 0xFA8E4264 : Passed.
+# umash32_hi           - Verification value 0x8C72DB99 : Passed.
 ### Sanity Tests ###
 # Sanity check simple key bit flips and consistency - hashbytes=4..........
 ok 3 - SanityTest # umash32_hi
@@ -14,85 +14,85 @@ ok 4 - Appended Zeroes Test # umash32_hi
 ok 5 - Sanity Test # umash32_hi
 ### Speed Tests ###
 ## Bulk speed test - 262144-byte keys
-# Alignment  7 -  8.756 bytes/cycle - 25051.11 MiB/sec @ 3 ghz
-# Alignment  6 -  9.152 bytes/cycle - 26184.94 MiB/sec @ 3 ghz
-# Alignment  5 -  8.012 bytes/cycle - 22921.31 MiB/sec @ 3 ghz
-# Alignment  4 -  9.754 bytes/cycle - 27905.14 MiB/sec @ 3 ghz
-# Alignment  3 -  9.442 bytes/cycle - 27014.73 MiB/sec @ 3 ghz
-# Alignment  2 -  9.167 bytes/cycle - 26227.07 MiB/sec @ 3 ghz
-# Alignment  1 -  9.208 bytes/cycle - 26343.15 MiB/sec @ 3 ghz
-# Alignment  0 -  9.502 bytes/cycle - 27185.59 MiB/sec @ 3 ghz
-# Average      -  9.124 bytes/cycle - 26104.13 MiB/sec @ 3 ghz
+# Alignment  7 -  7.233 bytes/cycle - 20694.72 MiB/sec @ 3 ghz
+# Alignment  6 -  7.201 bytes/cycle - 20601.78 MiB/sec @ 3 ghz
+# Alignment  5 -  7.206 bytes/cycle - 20617.46 MiB/sec @ 3 ghz
+# Alignment  4 -  7.695 bytes/cycle - 22015.64 MiB/sec @ 3 ghz
+# Alignment  3 -  6.835 bytes/cycle - 19554.97 MiB/sec @ 3 ghz
+# Alignment  2 -  7.072 bytes/cycle - 20231.97 MiB/sec @ 3 ghz
+# Alignment  1 -  6.971 bytes/cycle - 19944.44 MiB/sec @ 3 ghz
+# Alignment  0 -  6.960 bytes/cycle - 19912.58 MiB/sec @ 3 ghz
+# Average      -  7.147 bytes/cycle - 20446.69 MiB/sec @ 3 ghz
 ## KeySpeed tests
-# umash32_hi                0 byte keys       17.000 c/h
-# umash32_hi                1 byte keys       19.796 c/h       19.796 c/b        0.051 b/c
-# umash32_hi                2 byte keys       19.520 c/h        9.760 c/b        0.102 b/c
-# umash32_hi                3 byte keys       20.492 c/h        6.831 c/b        0.146 b/c
-# umash32_hi                4 byte keys       16.000 c/h        4.000 c/b        0.250 b/c
-# umash32_hi                5 byte keys       22.863 c/h        4.573 c/b        0.219 b/c
-# umash32_hi                6 byte keys       25.121 c/h        4.187 c/b        0.239 b/c
-# umash32_hi                7 byte keys       25.788 c/h        3.684 c/b        0.271 b/c
-# umash32_hi                8 byte keys       24.522 c/h        3.065 c/b        0.326 b/c
-# umash32_hi                9 byte keys       36.605 c/h        4.067 c/b        0.246 b/c
-# umash32_hi               10 byte keys       35.000 c/h        3.500 c/b        0.286 b/c
-# umash32_hi               11 byte keys       35.000 c/h        3.182 c/b        0.314 b/c
-# umash32_hi               12 byte keys       35.661 c/h        2.972 c/b        0.337 b/c
-# umash32_hi               13 byte keys       34.000 c/h        2.615 c/b        0.382 b/c
-# umash32_hi               14 byte keys       35.162 c/h        2.512 c/b        0.398 b/c
-# umash32_hi               15 byte keys       35.522 c/h        2.368 c/b        0.422 b/c
-# umash32_hi               16 byte keys       35.639 c/h        2.227 c/b        0.449 b/c
-# umash32_hi               17 byte keys       44.449 c/h        2.615 c/b        0.382 b/c
-# umash32_hi               18 byte keys       49.842 c/h        2.769 c/b        0.361 b/c
-# umash32_hi               19 byte keys       51.432 c/h        2.707 c/b        0.369 b/c
-# umash32_hi               20 byte keys       48.417 c/h        2.421 c/b        0.413 b/c
-# umash32_hi               21 byte keys       47.820 c/h        2.277 c/b        0.439 b/c
-# umash32_hi               22 byte keys       47.636 c/h        2.165 c/b        0.462 b/c
-# umash32_hi               23 byte keys       50.007 c/h        2.174 c/b        0.460 b/c
-# umash32_hi               24 byte keys       50.073 c/h        2.086 c/b        0.479 b/c
-# umash32_hi               25 byte keys       48.811 c/h        1.952 c/b        0.512 b/c
-# umash32_hi               26 byte keys       49.149 c/h        1.890 c/b        0.529 b/c
-# umash32_hi               27 byte keys       50.089 c/h        1.855 c/b        0.539 b/c
-# umash32_hi               28 byte keys       51.805 c/h        1.850 c/b        0.540 b/c
-# umash32_hi               29 byte keys       51.904 c/h        1.790 c/b        0.559 b/c
-# umash32_hi               30 byte keys       49.498 c/h        1.650 c/b        0.606 b/c
-# umash32_hi               31 byte keys       48.866 c/h        1.576 c/b        0.634 b/c
-#                          Average < 32       37.922 c/h        2.447 c/b        0.409 b/c
-# umash32_hi               32 byte keys       49.149 c/h        1.536 c/b        0.651 b/c
-# umash32_hi               36 byte keys       50.215 c/h        1.395 c/b        0.717 b/c
-# umash32_hi               40 byte keys       47.246 c/h        1.181 c/b        0.847 b/c
-# umash32_hi               44 byte keys       46.857 c/h        1.065 c/b        0.939 b/c
-# umash32_hi               48 byte keys       41.000 c/h        0.854 c/b        1.171 b/c
-# umash32_hi               52 byte keys       52.406 c/h        1.008 c/b        0.992 b/c
-# umash32_hi               56 byte keys       54.196 c/h        0.968 c/b        1.033 b/c
-# umash32_hi               60 byte keys       45.043 c/h        0.751 c/b        1.332 b/c
-# umash32_hi               64 byte keys       50.453 c/h        0.788 c/b        1.269 b/c
-# umash32_hi               68 byte keys       50.980 c/h        0.750 c/b        1.334 b/c
-# umash32_hi               72 byte keys       47.498 c/h        0.660 c/b        1.516 b/c
-# umash32_hi               76 byte keys       45.503 c/h        0.599 c/b        1.670 b/c
-# umash32_hi               80 byte keys       50.030 c/h        0.625 c/b        1.599 b/c
-# umash32_hi               84 byte keys       52.671 c/h        0.627 c/b        1.595 b/c
-# umash32_hi               88 byte keys       60.753 c/h        0.690 c/b        1.448 b/c
-# umash32_hi               92 byte keys       59.029 c/h        0.642 c/b        1.559 b/c
-# umash32_hi               96 byte keys       64.810 c/h        0.675 c/b        1.481 b/c
-# umash32_hi              100 byte keys       68.442 c/h        0.684 c/b        1.461 b/c
-# umash32_hi              104 byte keys       67.551 c/h        0.650 c/b        1.540 b/c
-# umash32_hi              108 byte keys       67.246 c/h        0.623 c/b        1.606 b/c
-# umash32_hi              112 byte keys       60.753 c/h        0.542 c/b        1.844 b/c
-# umash32_hi              116 byte keys       63.292 c/h        0.546 c/b        1.833 b/c
-# umash32_hi              120 byte keys       45.999 c/h        0.383 c/b        2.609 b/c
-# umash32_hi              124 byte keys       49.159 c/h        0.396 c/b        2.522 b/c
-#                         Average < 128       44.710 c/h        1.057 c/b        0.946 b/c
-# umash32_hi              128 byte keys       46.000 c/h        0.359 c/b        2.783 b/c
-# umash32_hi              256 byte keys       59.913 c/h        0.234 c/b        4.273 b/c
-# umash32_hi              512 byte keys      131.326 c/h        0.256 c/b        3.899 b/c
-# umash32_hi             1024 byte keys      240.522 c/h        0.235 c/b        4.257 b/c
-# umash32_hi             2048 byte keys      446.089 c/h        0.218 c/b        4.591 b/c
-# umash32_hi             4096 byte keys      643.195 c/h        0.157 c/b        6.368 b/c
-# umash32_hi             8192 byte keys     1325.262 c/h        0.162 c/b        6.181 b/c
-# umash32_hi            16384 byte keys     2499.207 c/h        0.153 c/b        6.556 b/c
-# umash32_hi            32768 byte keys     4130.723 c/h        0.126 c/b        7.933 b/c
-# umash32_hi            65536 byte keys    10230.420 c/h        0.156 c/b        6.406 b/c
-#                       Overall Average      337.219 c/h        0.167 c/b        5.990 b/c
+# umash32_hi                0 byte keys       29.947 c/h
+# umash32_hi                1 byte keys       25.499 c/h       25.499 c/b        0.039 b/c
+# umash32_hi                2 byte keys       26.320 c/h       13.160 c/b        0.076 b/c
+# umash32_hi                3 byte keys       18.000 c/h        6.000 c/b        0.167 b/c
+# umash32_hi                4 byte keys       21.752 c/h        5.438 c/b        0.184 b/c
+# umash32_hi                5 byte keys       24.000 c/h        4.800 c/b        0.208 b/c
+# umash32_hi                6 byte keys       23.721 c/h        3.954 c/b        0.253 b/c
+# umash32_hi                7 byte keys       23.000 c/h        3.286 c/b        0.304 b/c
+# umash32_hi                8 byte keys       24.448 c/h        3.056 c/b        0.327 b/c
+# umash32_hi                9 byte keys       31.506 c/h        3.501 c/b        0.286 b/c
+# umash32_hi               10 byte keys       37.543 c/h        3.754 c/b        0.266 b/c
+# umash32_hi               11 byte keys       36.119 c/h        3.284 c/b        0.305 b/c
+# umash32_hi               12 byte keys       32.739 c/h        2.728 c/b        0.367 b/c
+# umash32_hi               13 byte keys       31.668 c/h        2.436 c/b        0.411 b/c
+# umash32_hi               14 byte keys       37.293 c/h        2.664 c/b        0.375 b/c
+# umash32_hi               15 byte keys       35.101 c/h        2.340 c/b        0.427 b/c
+# umash32_hi               16 byte keys       33.057 c/h        2.066 c/b        0.484 b/c
+# umash32_hi               17 byte keys       42.434 c/h        2.496 c/b        0.401 b/c
+# umash32_hi               18 byte keys       44.520 c/h        2.473 c/b        0.404 b/c
+# umash32_hi               19 byte keys       43.574 c/h        2.293 c/b        0.436 b/c
+# umash32_hi               20 byte keys       39.895 c/h        1.995 c/b        0.501 b/c
+# umash32_hi               21 byte keys       39.692 c/h        1.890 c/b        0.529 b/c
+# umash32_hi               22 byte keys       42.608 c/h        1.937 c/b        0.516 b/c
+# umash32_hi               23 byte keys       47.675 c/h        2.073 c/b        0.482 b/c
+# umash32_hi               24 byte keys       47.632 c/h        1.985 c/b        0.504 b/c
+# umash32_hi               25 byte keys       45.429 c/h        1.817 c/b        0.550 b/c
+# umash32_hi               26 byte keys       49.405 c/h        1.900 c/b        0.526 b/c
+# umash32_hi               27 byte keys       47.934 c/h        1.775 c/b        0.563 b/c
+# umash32_hi               28 byte keys       41.830 c/h        1.494 c/b        0.669 b/c
+# umash32_hi               29 byte keys       45.035 c/h        1.553 c/b        0.644 b/c
+# umash32_hi               30 byte keys       49.849 c/h        1.662 c/b        0.602 b/c
+# umash32_hi               31 byte keys       49.886 c/h        1.609 c/b        0.621 b/c
+#                          Average < 32       36.535 c/h        2.357 c/b        0.424 b/c
+# umash32_hi               32 byte keys       49.806 c/h        1.556 c/b        0.642 b/c
+# umash32_hi               36 byte keys       51.807 c/h        1.439 c/b        0.695 b/c
+# umash32_hi               40 byte keys       50.087 c/h        1.252 c/b        0.799 b/c
+# umash32_hi               44 byte keys       52.117 c/h        1.184 c/b        0.844 b/c
+# umash32_hi               48 byte keys       48.015 c/h        1.000 c/b        1.000 b/c
+# umash32_hi               52 byte keys       51.706 c/h        0.994 c/b        1.006 b/c
+# umash32_hi               56 byte keys       49.331 c/h        0.881 c/b        1.135 b/c
+# umash32_hi               60 byte keys       52.018 c/h        0.867 c/b        1.153 b/c
+# umash32_hi               64 byte keys       51.080 c/h        0.798 c/b        1.253 b/c
+# umash32_hi               68 byte keys       49.381 c/h        0.726 c/b        1.377 b/c
+# umash32_hi               72 byte keys       52.271 c/h        0.726 c/b        1.377 b/c
+# umash32_hi               76 byte keys       45.491 c/h        0.599 c/b        1.671 b/c
+# umash32_hi               80 byte keys       53.020 c/h        0.663 c/b        1.509 b/c
+# umash32_hi               84 byte keys       58.399 c/h        0.695 c/b        1.438 b/c
+# umash32_hi               88 byte keys       58.272 c/h        0.662 c/b        1.510 b/c
+# umash32_hi               92 byte keys       58.384 c/h        0.635 c/b        1.576 b/c
+# umash32_hi               96 byte keys       57.510 c/h        0.599 c/b        1.669 b/c
+# umash32_hi              100 byte keys       59.372 c/h        0.594 c/b        1.684 b/c
+# umash32_hi              104 byte keys       61.635 c/h        0.593 c/b        1.687 b/c
+# umash32_hi              108 byte keys       51.691 c/h        0.479 c/b        2.089 b/c
+# umash32_hi              112 byte keys       56.187 c/h        0.502 c/b        1.993 b/c
+# umash32_hi              116 byte keys       59.580 c/h        0.514 c/b        1.947 b/c
+# umash32_hi              120 byte keys       61.517 c/h        0.513 c/b        1.951 b/c
+# umash32_hi              124 byte keys       54.570 c/h        0.440 c/b        2.272 b/c
+#                         Average < 128       43.971 c/h        1.040 c/b        0.962 b/c
+# umash32_hi              128 byte keys       43.920 c/h        0.343 c/b        2.914 b/c
+# umash32_hi              256 byte keys      105.848 c/h        0.413 c/b        2.419 b/c
+# umash32_hi              512 byte keys      173.204 c/h        0.338 c/b        2.956 b/c
+# umash32_hi             1024 byte keys      226.860 c/h        0.222 c/b        4.514 b/c
+# umash32_hi             2048 byte keys      446.609 c/h        0.218 c/b        4.586 b/c
+# umash32_hi             4096 byte keys      752.511 c/h        0.184 c/b        5.443 b/c
+# umash32_hi             8192 byte keys     1210.079 c/h        0.148 c/b        6.770 b/c
+# umash32_hi            16384 byte keys     2309.074 c/h        0.141 c/b        7.095 b/c
+# umash32_hi            32768 byte keys     4528.430 c/h        0.138 c/b        7.236 b/c
+# umash32_hi            65536 byte keys     9283.904 c/h        0.142 c/b        7.059 b/c
+#                       Overall Average      326.406 c/h        0.162 c/b        6.188 b/c
 ok 6 - Speed (always passes) # umash32_hi
 ### Differential Tests ###
 # Testing 8303632 up-to-5-bit differentials in 64-bit keys -> 32 bit hashes.
@@ -2568,21 +2568,21 @@ ok 152 - Strict Avalanche Criteria - 48 bit/6 byte keys # umash32_hi
 ok 153 - Strict Avalanche Criteria - 56 bit/7 byte keys # umash32_hi
 # Testing  64-bit keys.......... ok.     # worst-bit:   0.609% error-ratio: 9.857275e-01
 ok 154 - Strict Avalanche Criteria - 64 bit/8 byte keys # umash32_hi
-# Testing  72-bit keys.......... ok.     # worst-bit:   0.644% error-ratio: 1.012735e+00
+# Testing  72-bit keys.......... ok.     # worst-bit:   0.582% error-ratio: 1.033480e+00
 ok 155 - Strict Avalanche Criteria - 72 bit/9 byte keys # umash32_hi
-# Testing  80-bit keys.......... ok.     # worst-bit:   0.640% error-ratio: 9.623798e-01
+# Testing  80-bit keys.......... ok.     # worst-bit:   0.576% error-ratio: 1.028612e+00
 ok 156 - Strict Avalanche Criteria - 80 bit/10 byte keys # umash32_hi
-# Testing  88-bit keys.......... ok.     # worst-bit:   0.629% error-ratio: 1.034698e+00
+# Testing  88-bit keys.......... ok.     # worst-bit:   0.650% error-ratio: 1.003218e+00
 ok 157 - Strict Avalanche Criteria - 88 bit/11 byte keys # umash32_hi
-# Testing  96-bit keys.......... ok.     # worst-bit:   0.614% error-ratio: 1.003801e+00
+# Testing  96-bit keys.......... ok.     # worst-bit:   0.580% error-ratio: 1.000685e+00
 ok 158 - Strict Avalanche Criteria - 96 bit/12 byte keys # umash32_hi
-# Testing 104-bit keys.......... ok.     # worst-bit:   0.666% error-ratio: 9.700258e-01
+# Testing 104-bit keys.......... ok.     # worst-bit:   0.626% error-ratio: 1.001052e+00
 ok 159 - Strict Avalanche Criteria - 104 bit/13 byte keys # umash32_hi
-# Testing 112-bit keys.......... ok.     # worst-bit:   0.700% error-ratio: 9.796567e-01
+# Testing 112-bit keys.......... ok.     # worst-bit:   0.615% error-ratio: 9.951563e-01
 ok 160 - Strict Avalanche Criteria - 112 bit/14 byte keys # umash32_hi
-# Testing 120-bit keys.......... ok.     # worst-bit:   0.584% error-ratio: 9.820192e-01
+# Testing 120-bit keys.......... ok.     # worst-bit:   0.624% error-ratio: 1.007401e+00
 ok 161 - Strict Avalanche Criteria - 120 bit/15 byte keys # umash32_hi
-# Testing 128-bit keys.......... ok.     # worst-bit:   0.557% error-ratio: 9.755675e-01
+# Testing 128-bit keys.......... ok.     # worst-bit:   0.607% error-ratio: 1.017534e+00
 ok 162 - Strict Avalanche Criteria - 128 bit/16 byte keys # umash32_hi
 # Testing 136-bit keys.......... ok.     # worst-bit:   0.589% error-ratio: 1.005546e+00
 ok 163 - Strict Avalanche Criteria - 136 bit/17 byte keys # umash32_hi
@@ -3133,7 +3133,7 @@ ok 172 - Strict Avalanche Criteria - 2048 bit/256 byte keys # umash32_hi
 ----------------------------------------------------------------------------------------------------
 ( 30, 31) - ........................................................................................
 ----------------------------------------------------------------------------------------------------
-# Max bias 0.005302 - ( 39 :   0, 15)
+# Max bias 0.005470 - ( 51 :  10, 21)
 ok 173 - Bit Independence Criteria (BicTest3) # umash32_hi
 ### Keyset 'Cyclic' Tests ###
 # Keyset 'Cyclic' - 8 cycles of 4 bytes - 10000000 keys
@@ -3164,13 +3164,13 @@ ok 186 - Distribution Bias Check for Keyset 'TwoBytes' - up-to-4-byte keys, 6525
 # Testing collisions   - Expected  3484.56, actual     3460 ( 0.99x) - passed
 ok 187 - Collision Rate for Keyset 'TwoBytes' - up-to-8-byte keys, 5471025 total keys
 ok 188 - Distribution Bias Check for Keyset 'TwoBytes' - up-to-8-byte keys, 5471025 total keys
-# Testing collisions   - Expected 40347.77, actual    40486 ( 1.00x) - passed
+# Testing collisions   - Expected 40347.77, actual    40144 ( 0.99x) - passed
 ok 189 - Collision Rate for Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
 ok 190 - Distribution Bias Check for Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
-# Testing collisions   - Expected 227963.15, actual   227869 ( 1.00x) - passed
+# Testing collisions   - Expected 227963.15, actual   226815 ( 0.99x) - passed
 ok 191 - Collision Rate for Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
 ok 192 - Distribution Bias Check for Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
-# Testing collisions   - Expected 871784.70, actual   866398 ( 0.99x) - passed
+# Testing collisions   - Expected 871784.70, actual   865870 ( 0.99x) - passed
 ok 193 - Collision Rate for Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
 ok 194 - Distribution Bias Check for Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
 ok 195 - Keyset 'TwoBytes' # umash32_hi
@@ -3216,7 +3216,7 @@ ok 213 - Distribution Bias Check for Keyset 'Sparse' - 56-bit keys with up to 5 
 ok 214 - Collision Rate for Keyset 'Sparse' - 64-bit keys with up to 5 bits set
 ok 215 - Distribution Bias Check for Keyset 'Sparse' - 64-bit keys with up to 5 bits set
 # Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
-# Testing collisions   - Expected  1401.34, actual     1378 ( 0.98x) - passed
+# Testing collisions   - Expected  1401.34, actual     1333 ( 0.95x) - passed
 ok 216 - Collision Rate for Keyset 'Sparse' - 96-bit keys with up to 4 bits set
 ok 217 - Distribution Bias Check for Keyset 'Sparse' - 96-bit keys with up to 4 bits set
 ok 218 - Keyset 'Sparse' # umash32_hi
@@ -3353,19 +3353,19 @@ ok 277 - Collision Rate for Keyset 'City64-MultiCollision' - seed 9 # umash32_hi
 ok 278 - Collision Rate for Keyset 'City64-MultiCollision' - seed 10 # umash32_hi
 ### Keyset 'Combination Lowbits' Tests ###
 # Keyset 'Combination' - up to 8 blocks from a set of 8 - 19173960 keys
-# Testing collisions   - Expected 42799.01, actual    42766 ( 1.00x) - passed
+# Testing collisions   - Expected 42799.01, actual    42762 ( 1.00x) - passed
 ok 279 - Collision Rate for Keyset 'Combination Lowbits'
 ok 280 - Distribution Bias Check for Keyset 'Combination Lowbits'
 ok 281 - Keyset 'Combination Lowbits' # umash32_hi
 ### Keyset 'Combination Highbits' Tests ###
 # Keyset 'Combination' - up to 8 blocks from a set of 8 - 19173960 keys
-# Testing collisions   - Expected 42799.01, actual    42829 ( 1.00x) - passed
+# Testing collisions   - Expected 42799.01, actual    42825 ( 1.00x) - passed
 ok 282 - Collision Rate for Keyset 'Combination Highbits'
 ok 283 - Distribution Bias Check for Keyset 'Combination Highbits'
 ok 284 - Keyset 'Combination Highbits' # umash32_hi
 ### Keyset 'Combination Highbits2' Tests ###
 # Keyset 'Combination' - up to 8 blocks from a set of 8 - 19173960 keys
-# Testing collisions   - Expected 42799.01, actual    42983 ( 1.00x) - passed
+# Testing collisions   - Expected 42799.01, actual    42975 ( 1.00x) - passed
 ok 285 - Collision Rate for Keyset 'Combination Highbits2'
 ok 286 - Distribution Bias Check for Keyset 'Combination Highbits2'
 ok 287 - Keyset 'Combination Highbits2' # umash32_hi
@@ -3383,7 +3383,7 @@ ok 292 - Distribution Bias Check for Keyset 'Combination LowBit-Null'
 ok 293 - Keyset 'Combination LowBit-Null' # umash32_hi
 ### Keyset 'Combination Hi-Lo' Tests ###
 # Keyset 'Combination' - up to 6 blocks from a set of 15 - 12204240 keys
-# Testing collisions   - Expected 17339.30, actual    17432 ( 1.01x) - passed
+# Testing collisions   - Expected 17339.30, actual    17410 ( 1.00x) - passed
 ok 294 - Collision Rate for Keyset 'Combination Hi-Lo'
 ok 295 - Distribution Bias Check for Keyset 'Combination Hi-Lo'
 ok 296 - Keyset 'Combination Hi-Lo' # umash32_hi
@@ -3587,15 +3587,15 @@ ok 426 - Distribution Bias Check for Window at  64
 ok 427 - Keyset 'Window' # umash32_hi
 ### Keyset 'Text' Tests ###
 # Keyset 'Text' - keys of form "Foo[XXXX]Bar" - 14776336 keys
-# Testing collisions   - Expected 25418.13, actual    25698 ( 1.01x) - passed
+# Testing collisions   - Expected 25418.13, actual    25474 ( 1.00x) - passed
 ok 428 - Collision Rate for Keyset 'Text' - keys of form "Foo[XXXX]Bar" - 14776336 keys
 ok 429 - Distribution Bias Check for Keyset 'Text' - keys of form "Foo[XXXX]Bar" - 14776336 keys
 # Keyset 'Text' - keys of form "FooBar[XXXX]" - 14776336 keys
-# Testing collisions   - Expected 25418.13, actual    25282 ( 0.99x) - passed
+# Testing collisions   - Expected 25418.13, actual    25474 ( 1.00x) - passed
 ok 430 - Collision Rate for Keyset 'Text' - keys of form "FooBar[XXXX]" - 14776336 keys
 ok 431 - Distribution Bias Check for Keyset 'Text' - keys of form "FooBar[XXXX]" - 14776336 keys
 # Keyset 'Text' - keys of form "[XXXX]FooBar" - 14776336 keys
-# Testing collisions   - Expected 25418.13, actual    25275 ( 0.99x) - passed
+# Testing collisions   - Expected 25418.13, actual    25251 ( 0.99x) - passed
 ok 432 - Collision Rate for Keyset 'Text' - keys of form "[XXXX]FooBar" - 14776336 keys
 ok 433 - Distribution Bias Check for Keyset 'Text' - keys of form "[XXXX]FooBar" - 14776336 keys
 ok 434 - Keyset 'Text' # umash32_hi
@@ -3639,11 +3639,11 @@ ok 452 - Distribution Bias Check for Keyset 'Effs' - 262144 keys, nonzero seed
 ok 453 - Keyset 'Effs' # umash32_hi
 ### Keyset 'Words' Tests ###
 # Hashed 501909 keys from 167303 words from file '/usr/share/dict/words'
-# Testing collisions   - Expected    29.33, actual       30 ( 1.02x) - passed
+# Testing collisions   - Expected    29.33, actual       26 ( 0.89x) - passed
 ok 454 - Collision Rate for Keyset 'Words'
 ok 455 - Distribution Bias Check for Keyset 'Words'
 ok 456 - all tests passed # umash32_hi
 1..456
 # All Tests Passed. umash32_hi passed all 456 tests run.
-# Testing took 5171.070807 seconds
-# This is SMHasher version v1.3-demerphq-43-g0762887-dirty - built on Sep 19 2020.
+# Testing took 4349.520899 seconds
+# This is SMHasher version v1.3-demerphq-43-g0762887-dirty - built on Sep 22 2020.

--- a/smhasher/demerphq-umash64.log
+++ b/smhasher/demerphq-umash64.log
@@ -5,7 +5,7 @@ ok 1 - Found Hash # umash64
 ### seedbits: 64 statebits: 2560 hashbits: 64
 ###################################################################
 ok 2 - Verification code # umash64
-# umash64              - Verification value 0x78350DAF : Passed.
+# umash64              - Verification value 0x286B34EC : Passed.
 ### Sanity Tests ###
 # Sanity check simple key bit flips and consistency - hashbytes=8..........
 ok 3 - SanityTest # umash64
@@ -14,85 +14,85 @@ ok 4 - Appended Zeroes Test # umash64
 ok 5 - Sanity Test # umash64
 ### Speed Tests ###
 ## Bulk speed test - 262144-byte keys
-# Alignment  7 -  7.255 bytes/cycle - 20755.59 MiB/sec @ 3 ghz
-# Alignment  6 -  9.355 bytes/cycle - 26764.14 MiB/sec @ 3 ghz
-# Alignment  5 -  9.208 bytes/cycle - 26345.50 MiB/sec @ 3 ghz
-# Alignment  4 -  9.209 bytes/cycle - 26347.27 MiB/sec @ 3 ghz
-# Alignment  3 -  9.643 bytes/cycle - 27590.24 MiB/sec @ 3 ghz
-# Alignment  2 -  9.231 bytes/cycle - 26411.48 MiB/sec @ 3 ghz
-# Alignment  1 -  9.280 bytes/cycle - 26549.75 MiB/sec @ 3 ghz
-# Alignment  0 -  9.638 bytes/cycle - 27573.48 MiB/sec @ 3 ghz
-# Average      -  9.102 bytes/cycle - 26042.18 MiB/sec @ 3 ghz
+# Alignment  7 -  6.283 bytes/cycle - 17975.84 MiB/sec @ 3 ghz
+# Alignment  6 -  5.867 bytes/cycle - 16784.40 MiB/sec @ 3 ghz
+# Alignment  5 -  5.747 bytes/cycle - 16443.44 MiB/sec @ 3 ghz
+# Alignment  4 -  6.173 bytes/cycle - 17662.28 MiB/sec @ 3 ghz
+# Alignment  3 -  6.755 bytes/cycle - 19325.74 MiB/sec @ 3 ghz
+# Alignment  2 -  6.141 bytes/cycle - 17569.22 MiB/sec @ 3 ghz
+# Alignment  1 -  5.875 bytes/cycle - 16807.48 MiB/sec @ 3 ghz
+# Alignment  0 -  6.173 bytes/cycle - 17661.28 MiB/sec @ 3 ghz
+# Average      -  6.127 bytes/cycle - 17528.71 MiB/sec @ 3 ghz
 ## KeySpeed tests
-# umash64                   0 byte keys       17.202 c/h
-# umash64                   1 byte keys       17.860 c/h       17.860 c/b        0.056 b/c
-# umash64                   2 byte keys       17.765 c/h        8.882 c/b        0.113 b/c
-# umash64                   3 byte keys       17.000 c/h        5.667 c/b        0.176 b/c
-# umash64                   4 byte keys       16.441 c/h        4.110 c/b        0.243 b/c
-# umash64                   5 byte keys       16.000 c/h        3.200 c/b        0.312 b/c
-# umash64                   6 byte keys       16.228 c/h        2.705 c/b        0.370 b/c
-# umash64                   7 byte keys       16.000 c/h        2.286 c/b        0.438 b/c
-# umash64                   8 byte keys       16.000 c/h        2.000 c/b        0.500 b/c
-# umash64                   9 byte keys       35.000 c/h        3.889 c/b        0.257 b/c
-# umash64                  10 byte keys       33.940 c/h        3.394 c/b        0.295 b/c
-# umash64                  11 byte keys       34.127 c/h        3.102 c/b        0.322 b/c
-# umash64                  12 byte keys       34.470 c/h        2.872 c/b        0.348 b/c
-# umash64                  13 byte keys       34.226 c/h        2.633 c/b        0.380 b/c
-# umash64                  14 byte keys       34.619 c/h        2.473 c/b        0.404 b/c
-# umash64                  15 byte keys       35.000 c/h        2.333 c/b        0.429 b/c
-# umash64                  16 byte keys       28.911 c/h        1.807 c/b        0.553 b/c
-# umash64                  17 byte keys       38.713 c/h        2.277 c/b        0.439 b/c
-# umash64                  18 byte keys       38.828 c/h        2.157 c/b        0.464 b/c
-# umash64                  19 byte keys       38.092 c/h        2.005 c/b        0.499 b/c
-# umash64                  20 byte keys       38.090 c/h        1.905 c/b        0.525 b/c
-# umash64                  21 byte keys       38.297 c/h        1.824 c/b        0.548 b/c
-# umash64                  22 byte keys       38.090 c/h        1.731 c/b        0.578 b/c
-# umash64                  23 byte keys       37.709 c/h        1.640 c/b        0.610 b/c
-# umash64                  24 byte keys       37.886 c/h        1.579 c/b        0.633 b/c
-# umash64                  25 byte keys       36.000 c/h        1.440 c/b        0.694 b/c
-# umash64                  26 byte keys       41.124 c/h        1.582 c/b        0.632 b/c
-# umash64                  27 byte keys       37.047 c/h        1.372 c/b        0.729 b/c
-# umash64                  28 byte keys       37.439 c/h        1.337 c/b        0.748 b/c
-# umash64                  29 byte keys       39.125 c/h        1.349 c/b        0.741 b/c
-# umash64                  30 byte keys       37.265 c/h        1.242 c/b        0.805 b/c
-# umash64                  31 byte keys       36.000 c/h        1.161 c/b        0.861 b/c
-#                          Average < 32       30.953 c/h        1.997 c/b        0.501 b/c
-# umash64                  32 byte keys       36.000 c/h        1.125 c/b        0.889 b/c
-# umash64                  36 byte keys       37.000 c/h        1.028 c/b        0.973 b/c
-# umash64                  40 byte keys       43.070 c/h        1.077 c/b        0.929 b/c
-# umash64                  44 byte keys       37.000 c/h        0.841 c/b        1.189 b/c
-# umash64                  48 byte keys       37.000 c/h        0.771 c/b        1.297 b/c
-# umash64                  52 byte keys       42.399 c/h        0.815 c/b        1.226 b/c
-# umash64                  56 byte keys       37.997 c/h        0.679 c/b        1.474 b/c
-# umash64                  60 byte keys       42.406 c/h        0.707 c/b        1.415 b/c
-# umash64                  64 byte keys       41.348 c/h        0.646 c/b        1.548 b/c
-# umash64                  68 byte keys       38.000 c/h        0.559 c/b        1.789 b/c
-# umash64                  72 byte keys       40.000 c/h        0.556 c/b        1.800 b/c
-# umash64                  76 byte keys       40.000 c/h        0.526 c/b        1.900 b/c
-# umash64                  80 byte keys       40.000 c/h        0.500 c/b        2.000 b/c
-# umash64                  84 byte keys       41.000 c/h        0.488 c/b        2.049 b/c
-# umash64                  88 byte keys       39.705 c/h        0.451 c/b        2.216 b/c
-# umash64                  92 byte keys       40.936 c/h        0.445 c/b        2.247 b/c
-# umash64                  96 byte keys       40.475 c/h        0.422 c/b        2.372 b/c
-# umash64                 100 byte keys       40.770 c/h        0.408 c/b        2.453 b/c
-# umash64                 104 byte keys       40.000 c/h        0.385 c/b        2.600 b/c
-# umash64                 108 byte keys       40.000 c/h        0.370 c/b        2.700 b/c
-# umash64                 112 byte keys       40.000 c/h        0.357 c/b        2.800 b/c
-# umash64                 116 byte keys       46.497 c/h        0.401 c/b        2.495 b/c
-# umash64                 120 byte keys       45.248 c/h        0.377 c/b        2.652 b/c
-# umash64                 124 byte keys       39.763 c/h        0.321 c/b        3.118 b/c
-#                         Average < 128       34.948 c/h        0.826 c/b        1.210 b/c
-# umash64                 128 byte keys       41.000 c/h        0.320 c/b        3.122 b/c
-# umash64                 256 byte keys       54.377 c/h        0.212 c/b        4.708 b/c
-# umash64                 512 byte keys       86.314 c/h        0.169 c/b        5.932 b/c
-# umash64                1024 byte keys      135.336 c/h        0.132 c/b        7.566 b/c
-# umash64                2048 byte keys      231.307 c/h        0.113 c/b        8.854 b/c
-# umash64                4096 byte keys      423.725 c/h        0.103 c/b        9.667 b/c
-# umash64                8192 byte keys      808.416 c/h        0.099 c/b       10.133 b/c
-# umash64               16384 byte keys     1644.729 c/h        0.100 c/b        9.962 b/c
-# umash64               32768 byte keys     3310.409 c/h        0.101 c/b        9.898 b/c
-# umash64               65536 byte keys     6488.623 c/h        0.099 c/b       10.100 b/c
-#                       Overall Average      230.020 c/h        0.114 c/b        8.781 b/c
+# umash64                   0 byte keys       23.736 c/h
+# umash64                   1 byte keys       25.249 c/h       25.249 c/b        0.040 b/c
+# umash64                   2 byte keys       17.750 c/h        8.875 c/b        0.113 b/c
+# umash64                   3 byte keys       24.441 c/h        8.147 c/b        0.123 b/c
+# umash64                   4 byte keys       26.332 c/h        6.583 c/b        0.152 b/c
+# umash64                   5 byte keys       31.897 c/h        6.379 c/b        0.157 b/c
+# umash64                   6 byte keys       31.017 c/h        5.169 c/b        0.193 b/c
+# umash64                   7 byte keys       29.557 c/h        4.222 c/b        0.237 b/c
+# umash64                   8 byte keys       27.421 c/h        3.428 c/b        0.292 b/c
+# umash64                   9 byte keys       43.497 c/h        4.833 c/b        0.207 b/c
+# umash64                  10 byte keys       34.671 c/h        3.467 c/b        0.288 b/c
+# umash64                  11 byte keys       36.669 c/h        3.334 c/b        0.300 b/c
+# umash64                  12 byte keys       34.528 c/h        2.877 c/b        0.348 b/c
+# umash64                  13 byte keys       39.032 c/h        3.002 c/b        0.333 b/c
+# umash64                  14 byte keys       40.143 c/h        2.867 c/b        0.349 b/c
+# umash64                  15 byte keys       40.569 c/h        2.705 c/b        0.370 b/c
+# umash64                  16 byte keys       36.705 c/h        2.294 c/b        0.436 b/c
+# umash64                  17 byte keys       48.568 c/h        2.857 c/b        0.350 b/c
+# umash64                  18 byte keys       50.688 c/h        2.816 c/b        0.355 b/c
+# umash64                  19 byte keys       49.697 c/h        2.616 c/b        0.382 b/c
+# umash64                  20 byte keys       50.020 c/h        2.501 c/b        0.400 b/c
+# umash64                  21 byte keys       47.167 c/h        2.246 c/b        0.445 b/c
+# umash64                  22 byte keys       47.318 c/h        2.151 c/b        0.465 b/c
+# umash64                  23 byte keys       45.905 c/h        1.996 c/b        0.501 b/c
+# umash64                  24 byte keys       45.290 c/h        1.887 c/b        0.530 b/c
+# umash64                  25 byte keys       44.661 c/h        1.786 c/b        0.560 b/c
+# umash64                  26 byte keys       46.392 c/h        1.784 c/b        0.560 b/c
+# umash64                  27 byte keys       44.168 c/h        1.636 c/b        0.611 b/c
+# umash64                  28 byte keys       48.116 c/h        1.718 c/b        0.582 b/c
+# umash64                  29 byte keys       48.453 c/h        1.671 c/b        0.599 b/c
+# umash64                  30 byte keys       47.752 c/h        1.592 c/b        0.628 b/c
+# umash64                  31 byte keys       39.345 c/h        1.269 c/b        0.788 b/c
+#                          Average < 32       38.961 c/h        2.514 c/b        0.398 b/c
+# umash64                  32 byte keys       43.088 c/h        1.347 c/b        0.743 b/c
+# umash64                  36 byte keys       42.738 c/h        1.187 c/b        0.842 b/c
+# umash64                  40 byte keys       46.966 c/h        1.174 c/b        0.852 b/c
+# umash64                  44 byte keys       46.066 c/h        1.047 c/b        0.955 b/c
+# umash64                  48 byte keys       44.170 c/h        0.920 c/b        1.087 b/c
+# umash64                  52 byte keys       46.180 c/h        0.888 c/b        1.126 b/c
+# umash64                  56 byte keys       45.012 c/h        0.804 c/b        1.244 b/c
+# umash64                  60 byte keys       43.131 c/h        0.719 c/b        1.391 b/c
+# umash64                  64 byte keys       41.628 c/h        0.650 c/b        1.537 b/c
+# umash64                  68 byte keys       59.248 c/h        0.871 c/b        1.148 b/c
+# umash64                  72 byte keys       56.805 c/h        0.789 c/b        1.268 b/c
+# umash64                  76 byte keys       61.930 c/h        0.815 c/b        1.227 b/c
+# umash64                  80 byte keys       55.236 c/h        0.690 c/b        1.448 b/c
+# umash64                  84 byte keys       56.823 c/h        0.676 c/b        1.478 b/c
+# umash64                  88 byte keys       60.021 c/h        0.682 c/b        1.466 b/c
+# umash64                  92 byte keys       61.296 c/h        0.666 c/b        1.501 b/c
+# umash64                  96 byte keys       58.961 c/h        0.614 c/b        1.628 b/c
+# umash64                 100 byte keys       49.764 c/h        0.498 c/b        2.009 b/c
+# umash64                 104 byte keys       56.107 c/h        0.539 c/b        1.854 b/c
+# umash64                 108 byte keys       60.301 c/h        0.558 c/b        1.791 b/c
+# umash64                 112 byte keys       58.997 c/h        0.527 c/b        1.898 b/c
+# umash64                 116 byte keys       46.947 c/h        0.405 c/b        2.471 b/c
+# umash64                 120 byte keys       45.391 c/h        0.378 c/b        2.644 b/c
+# umash64                 124 byte keys       57.674 c/h        0.465 c/b        2.150 b/c
+#                         Average < 128       44.486 c/h        1.052 c/b        0.951 b/c
+# umash64                 128 byte keys       45.000 c/h        0.352 c/b        2.844 b/c
+# umash64                 256 byte keys      112.608 c/h        0.440 c/b        2.273 b/c
+# umash64                 512 byte keys      176.241 c/h        0.344 c/b        2.905 b/c
+# umash64                1024 byte keys      268.595 c/h        0.262 c/b        3.812 b/c
+# umash64                2048 byte keys      408.770 c/h        0.200 c/b        5.010 b/c
+# umash64                4096 byte keys      722.582 c/h        0.176 c/b        5.669 b/c
+# umash64                8192 byte keys     1369.909 c/h        0.167 c/b        5.980 b/c
+# umash64               16384 byte keys     2676.069 c/h        0.163 c/b        6.122 b/c
+# umash64               32768 byte keys     5360.742 c/h        0.164 c/b        6.113 b/c
+# umash64               65536 byte keys    11121.204 c/h        0.170 c/b        5.893 b/c
+#                       Overall Average      375.045 c/h        0.186 c/b        5.386 b/c
 ok 6 - Speed (always passes) # umash64
 ### Differential Tests ###
 # Testing 8303632 up-to-5-bit differentials in 64-bit keys -> 64 bit hashes.
@@ -4616,21 +4616,21 @@ ok 152 - Strict Avalanche Criteria - 48 bit/6 byte keys # umash64
 ok 153 - Strict Avalanche Criteria - 56 bit/7 byte keys # umash64
 # Testing  64-bit keys.......... ok.     # worst-bit:   0.609% error-ratio: 1.000320e+00
 ok 154 - Strict Avalanche Criteria - 64 bit/8 byte keys # umash64
-# Testing  72-bit keys.......... ok.     # worst-bit:   0.644% error-ratio: 1.005286e+00
+# Testing  72-bit keys.......... ok.     # worst-bit:   0.582% error-ratio: 1.020977e+00
 ok 155 - Strict Avalanche Criteria - 72 bit/9 byte keys # umash64
-# Testing  80-bit keys.......... ok.     # worst-bit:   0.640% error-ratio: 9.521805e-01
+# Testing  80-bit keys.......... ok.     # worst-bit:   0.602% error-ratio: 1.014890e+00
 ok 156 - Strict Avalanche Criteria - 80 bit/10 byte keys # umash64
-# Testing  88-bit keys.......... ok.     # worst-bit:   0.629% error-ratio: 1.012750e+00
+# Testing  88-bit keys.......... ok.     # worst-bit:   0.650% error-ratio: 9.853369e-01
 ok 157 - Strict Avalanche Criteria - 88 bit/11 byte keys # umash64
-# Testing  96-bit keys.......... ok.     # worst-bit:   0.614% error-ratio: 9.911331e-01
+# Testing  96-bit keys.......... ok.     # worst-bit:   0.580% error-ratio: 1.005077e+00
 ok 158 - Strict Avalanche Criteria - 96 bit/12 byte keys # umash64
-# Testing 104-bit keys.......... ok.     # worst-bit:   0.666% error-ratio: 9.644262e-01
+# Testing 104-bit keys.......... ok.     # worst-bit:   0.626% error-ratio: 9.971130e-01
 ok 159 - Strict Avalanche Criteria - 104 bit/13 byte keys # umash64
-# Testing 112-bit keys.......... ok.     # worst-bit:   0.700% error-ratio: 9.896008e-01
+# Testing 112-bit keys.......... ok.     # worst-bit:   0.615% error-ratio: 9.942629e-01
 ok 160 - Strict Avalanche Criteria - 112 bit/14 byte keys # umash64
-# Testing 120-bit keys.......... ok.     # worst-bit:   0.584% error-ratio: 9.890568e-01
+# Testing 120-bit keys.......... ok.     # worst-bit:   0.624% error-ratio: 9.866104e-01
 ok 161 - Strict Avalanche Criteria - 120 bit/15 byte keys # umash64
-# Testing 128-bit keys.......... ok.     # worst-bit:   0.750% error-ratio: 9.997767e-01
+# Testing 128-bit keys.......... ok.     # worst-bit:   0.607% error-ratio: 1.002400e+00
 ok 162 - Strict Avalanche Criteria - 128 bit/16 byte keys # umash64
 # Testing 136-bit keys.......... ok.     # worst-bit:   0.589% error-ratio: 1.017356e+00
 ok 163 - Strict Avalanche Criteria - 136 bit/17 byte keys # umash64
@@ -6733,7 +6733,7 @@ ok 172 - Strict Avalanche Criteria - 2048 bit/256 byte keys # umash64
 ----------------------------------------------------------------------------------------------------
 ( 62, 63) - ........................................................................................
 ----------------------------------------------------------------------------------------------------
-# Max bias 0.005866 - ( 65 :  18, 21)
+# Max bias 0.006058 - ( 60 :  14, 21)
 ok 173 - Bit Independence Criteria (BicTest3) # umash64
 ### Keyset 'Cyclic' Tests ###
 # Keyset 'Cyclic' - 8 cycles of 8 bytes - 10000000 keys
@@ -7437,5 +7437,5 @@ ok 583 - Distribution Bias Check for Keyset 'Words'
 ok 584 - all tests passed # umash64
 1..584
 # All Tests Passed. umash64 passed all 584 tests run.
-# Testing took 6550.395287 seconds
-# This is SMHasher version v1.3-demerphq-43-g0762887-dirty - built on Sep 19 2020.
+# Testing took 7734.276324 seconds
+# This is SMHasher version v1.3-demerphq-43-g0762887-dirty - built on Sep 22 2020.

--- a/smhasher/umash128.log
+++ b/smhasher/umash128.log
@@ -3,65 +3,65 @@
 
 [[[ Sanity Tests ]]]
 
-Verification value 0x1DC98997 ....... PASS
+Verification value 0x5827960B ....... PASS
 Running sanity check 1     .......... PASS
 Running AppendedZeroesTest .......... PASS
 
 [[[ Speed Tests ]]]
 
 Bulk speed test - 262144-byte keys
-Alignment  7 -  4.622 bytes/cycle - 13224.57 MiB/sec @ 3 ghz
-Alignment  6 -  3.549 bytes/cycle - 10152.71 MiB/sec @ 3 ghz
-Alignment  5 -  3.190 bytes/cycle - 9125.60 MiB/sec @ 3 ghz
-Alignment  4 -  3.207 bytes/cycle - 9175.02 MiB/sec @ 3 ghz
-Alignment  3 -  2.966 bytes/cycle - 8485.90 MiB/sec @ 3 ghz
-Alignment  2 -  3.174 bytes/cycle - 9081.66 MiB/sec @ 3 ghz
-Alignment  1 -  2.557 bytes/cycle - 7316.91 MiB/sec @ 3 ghz
-Alignment  0 -  3.817 bytes/cycle - 10920.31 MiB/sec @ 3 ghz
-Average      -  3.385 bytes/cycle - 9685.34 MiB/sec @ 3 ghz
+Alignment  7 -  3.971 bytes/cycle - 11360.96 MiB/sec @ 3 ghz
+Alignment  6 -  3.715 bytes/cycle - 10627.96 MiB/sec @ 3 ghz
+Alignment  5 -  4.110 bytes/cycle - 11757.62 MiB/sec @ 3 ghz
+Alignment  4 -  4.222 bytes/cycle - 12079.21 MiB/sec @ 3 ghz
+Alignment  3 -  4.288 bytes/cycle - 12268.71 MiB/sec @ 3 ghz
+Alignment  2 -  4.037 bytes/cycle - 11551.24 MiB/sec @ 3 ghz
+Alignment  1 -  3.818 bytes/cycle - 10924.70 MiB/sec @ 3 ghz
+Alignment  0 -  4.171 bytes/cycle - 11932.65 MiB/sec @ 3 ghz
+Average      -  4.042 bytes/cycle - 11562.88 MiB/sec @ 3 ghz
 
-Small key speed test -    1-byte keys -    21.38 cycles/hash
-Small key speed test -    2-byte keys -    19.00 cycles/hash
-Small key speed test -    3-byte keys -    21.88 cycles/hash
-Small key speed test -    4-byte keys -    19.00 cycles/hash
-Small key speed test -    5-byte keys -    29.79 cycles/hash
-Small key speed test -    6-byte keys -    30.19 cycles/hash
-Small key speed test -    7-byte keys -    31.98 cycles/hash
-Small key speed test -    8-byte keys -    28.50 cycles/hash
-Small key speed test -    9-byte keys -    50.00 cycles/hash
-Small key speed test -   10-byte keys -    50.15 cycles/hash
-Small key speed test -   11-byte keys -    49.73 cycles/hash
-Small key speed test -   12-byte keys -    50.14 cycles/hash
-Small key speed test -   13-byte keys -    50.17 cycles/hash
-Small key speed test -   14-byte keys -    51.19 cycles/hash
-Small key speed test -   15-byte keys -    50.63 cycles/hash
-Small key speed test -   16-byte keys -    49.26 cycles/hash
-Small key speed test -   17-byte keys -    61.64 cycles/hash
-Small key speed test -   18-byte keys -    58.48 cycles/hash
-Small key speed test -   19-byte keys -    63.26 cycles/hash
-Small key speed test -   20-byte keys -    59.63 cycles/hash
-Small key speed test -   21-byte keys -    56.27 cycles/hash
-Small key speed test -   22-byte keys -    53.06 cycles/hash
-Small key speed test -   23-byte keys -    63.48 cycles/hash
-Small key speed test -   24-byte keys -    64.43 cycles/hash
-Small key speed test -   25-byte keys -    61.76 cycles/hash
-Small key speed test -   26-byte keys -    52.01 cycles/hash
-Small key speed test -   27-byte keys -    54.03 cycles/hash
-Small key speed test -   28-byte keys -    60.88 cycles/hash
-Small key speed test -   29-byte keys -    48.81 cycles/hash
-Small key speed test -   30-byte keys -    59.79 cycles/hash
-Small key speed test -   31-byte keys -    63.15 cycles/hash
-Average                                    47.861 cycles/hash
+Small key speed test -    1-byte keys -    29.31 cycles/hash
+Small key speed test -    2-byte keys -    31.21 cycles/hash
+Small key speed test -    3-byte keys -    33.15 cycles/hash
+Small key speed test -    4-byte keys -    28.41 cycles/hash
+Small key speed test -    5-byte keys -    35.96 cycles/hash
+Small key speed test -    6-byte keys -    33.66 cycles/hash
+Small key speed test -    7-byte keys -    31.59 cycles/hash
+Small key speed test -    8-byte keys -    27.36 cycles/hash
+Small key speed test -    9-byte keys -    44.21 cycles/hash
+Small key speed test -   10-byte keys -    40.00 cycles/hash
+Small key speed test -   11-byte keys -    44.15 cycles/hash
+Small key speed test -   12-byte keys -    48.41 cycles/hash
+Small key speed test -   13-byte keys -    45.17 cycles/hash
+Small key speed test -   14-byte keys -    40.53 cycles/hash
+Small key speed test -   15-byte keys -    44.86 cycles/hash
+Small key speed test -   16-byte keys -    42.80 cycles/hash
+Small key speed test -   17-byte keys -    58.64 cycles/hash
+Small key speed test -   18-byte keys -    58.33 cycles/hash
+Small key speed test -   19-byte keys -    49.08 cycles/hash
+Small key speed test -   20-byte keys -    44.82 cycles/hash
+Small key speed test -   21-byte keys -    44.81 cycles/hash
+Small key speed test -   22-byte keys -    47.82 cycles/hash
+Small key speed test -   23-byte keys -    44.82 cycles/hash
+Small key speed test -   24-byte keys -    57.53 cycles/hash
+Small key speed test -   25-byte keys -    54.47 cycles/hash
+Small key speed test -   26-byte keys -    54.01 cycles/hash
+Small key speed test -   27-byte keys -    51.54 cycles/hash
+Small key speed test -   28-byte keys -    58.61 cycles/hash
+Small key speed test -   29-byte keys -    51.54 cycles/hash
+Small key speed test -   30-byte keys -    51.76 cycles/hash
+Small key speed test -   31-byte keys -    49.21 cycles/hash
+Average                                    44.444 cycles/hash
 
 [[[ 'Hashmap' Speed Tests ]]]
 
 std::unordered_map
-Init std HashMapTest:     733.617 cycles/op (167303 inserts, 1% deletions)
-Running std HashMapTest:  425.415 cycles/op (37.0 stdv)
+Init std HashMapTest:     478.036 cycles/op (167303 inserts, 1% deletions)
+Running std HashMapTest:  405.708 cycles/op (35.3 stdv)
 
 greg7mdp/parallel-hashmap
-Init fast HashMapTest:    304.220 cycles/op (167303 inserts, 1% deletions)
-Running fast HashMapTest: 296.582 cycles/op (24.9 stdv)  ....... PASS
+Init fast HashMapTest:    310.051 cycles/op (167303 inserts, 1% deletions)
+Running fast HashMapTest: 295.223 cycles/op (37.9 stdv)  ....... PASS
 
 [[[ Avalanche Tests ]]]
 
@@ -71,11 +71,11 @@ Testing   40-bit keys -> 128-bit hashes, 300000 reps worst bias is 0.694667%
 Testing   48-bit keys -> 128-bit hashes, 300000 reps worst bias is 0.682667%
 Testing   56-bit keys -> 128-bit hashes, 300000 reps worst bias is 0.714000%
 Testing   64-bit keys -> 128-bit hashes, 300000 reps worst bias is 0.688667%
-Testing   72-bit keys -> 128-bit hashes, 300000 reps worst bias is 0.743333%
-Testing   80-bit keys -> 128-bit hashes, 300000 reps worst bias is 0.757333%
-Testing   96-bit keys -> 128-bit hashes, 300000 reps worst bias is 0.746000%
-Testing  112-bit keys -> 128-bit hashes, 300000 reps worst bias is 0.783333%
-Testing  128-bit keys -> 128-bit hashes, 300000 reps worst bias is 0.880000%
+Testing   72-bit keys -> 128-bit hashes, 300000 reps worst bias is 0.698667%
+Testing   80-bit keys -> 128-bit hashes, 300000 reps worst bias is 0.764000%
+Testing   96-bit keys -> 128-bit hashes, 300000 reps worst bias is 0.692667%
+Testing  112-bit keys -> 128-bit hashes, 300000 reps worst bias is 0.684667%
+Testing  128-bit keys -> 128-bit hashes, 300000 reps worst bias is 0.724667%
 Testing  160-bit keys -> 128-bit hashes, 300000 reps worst bias is 0.776000%
 
 [[[ Keyset 'Sparse' Tests ]]]
@@ -181,30 +181,30 @@ Testing distribution - Worst bias is the 20-bit window at bit 10 - 0.038%
 Keyset 'Sparse' - 72-bit keys with up to 5 bits set - 15082603 keys
 Testing collisions (128-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      26482.7, actual  26655 (1.01x) (173)
-Testing collisions (high 27-42 bits) - Worst is 40 bits: 107/103 (1.03x)
+Testing collisions (high 32-bit) - Expected      26482.7, actual  26292 (0.99x) (-190)
+Testing collisions (high 27-42 bits) - Worst is 39 bits: 215/206 (1.04x)
 Testing collisions (high 12-bit) - Expected   15078507.0, actual 15078507 (1.00x)
 Testing collisions (high  8-bit) - Expected   15082347.0, actual 15082347 (1.00x)
 Testing collisions (low  64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (low  32-bit) - Expected      26482.7, actual  26601 (1.00x) (119)
-Testing collisions (low  27-42 bits) - Worst is 41 bits: 63/51 (1.22x)
+Testing collisions (low  32-bit) - Expected      26482.7, actual  26163 (0.99x) (-319)
+Testing collisions (low  27-42 bits) - Worst is 42 bits: 28/25 (1.08x)
 Testing collisions (low  12-bit) - Expected   15078507.0, actual 15078507 (1.00x)
 Testing collisions (low   8-bit) - Expected   15082347.0, actual 15082347 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit  5 - 0.024%
+Testing distribution - Worst bias is the 20-bit window at bit 27 - 0.027%
 
 Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
 Testing collisions (128-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1401.3, actual   1389 (0.99x) (-12)
-Testing collisions (high 25-38 bits) - Worst is 37 bits: 48/43 (1.10x)
+Testing collisions (high 32-bit) - Expected       1401.3, actual   1436 (1.02x) (35)
+Testing collisions (high 25-38 bits) - Worst is 31 bits: 2890/2802 (1.03x)
 Testing collisions (high 12-bit) - Expected    3465401.0, actual 3465401 (1.00x)
 Testing collisions (high  8-bit) - Expected    3469241.0, actual 3469241 (1.00x)
 Testing collisions (low  64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (low  32-bit) - Expected       1401.3, actual   1471 (1.05x) (70)
-Testing collisions (low  25-38 bits) - Worst is 37 bits: 48/43 (1.10x)
+Testing collisions (low  32-bit) - Expected       1401.3, actual   1346 (0.96x)
+Testing collisions (low  25-38 bits) - Worst is 29 bits: 11155/11210 (1.00x)
 Testing collisions (low  12-bit) - Expected    3465401.0, actual 3465401 (1.00x)
 Testing collisions (low   8-bit) - Expected    3469241.0, actual 3469241 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 64 - 0.075%
+Testing distribution - Worst bias is the 19-bit window at bit 99 - 0.080%
 
 Keyset 'Sparse' - 160-bit keys with up to 4 bits set - 26977161 keys
 Testing collisions (128-bit) - Expected    0.0, actual      0 (0.00x)
@@ -241,48 +241,48 @@ Combination Lowbits Tests:
 Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
 Testing collisions (128-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        668.7, actual    681 (1.02x) (13)
-Testing collisions (high 25-37 bits) - Worst is 37 bits: 26/20 (1.24x)
+Testing collisions (high 32-bit) - Expected        668.7, actual    676 (1.01x) (8)
+Testing collisions (high 25-37 bits) - Worst is 37 bits: 24/20 (1.15x)
 Testing collisions (high 12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
 Testing collisions (high  8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
 Testing collisions (low  64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (low  32-bit) - Expected        668.7, actual    717 (1.07x) (49)
-Testing collisions (low  25-37 bits) - Worst is 32 bits: 717/668 (1.07x)
+Testing collisions (low  32-bit) - Expected        668.7, actual    720 (1.08x) (52)
+Testing collisions (low  25-37 bits) - Worst is 32 bits: 720/668 (1.08x)
 Testing collisions (low  12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
 Testing collisions (low   8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit 79 - 0.092%
+Testing distribution - Worst bias is the 18-bit window at bit 79 - 0.089%
 
 
 Combination Highbits Tests
 Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
 Testing collisions (128-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        668.7, actual    665 (0.99x) (-3)
-Testing collisions (high 25-37 bits) - Worst is 37 bits: 26/20 (1.24x)
+Testing collisions (high 32-bit) - Expected        668.7, actual    666 (1.00x) (-2)
+Testing collisions (high 25-37 bits) - Worst is 37 bits: 27/20 (1.29x)
 Testing collisions (high 12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
 Testing collisions (high  8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
 Testing collisions (low  64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (low  32-bit) - Expected        668.7, actual    675 (1.01x) (7)
-Testing collisions (low  25-37 bits) - Worst is 36 bits: 45/41 (1.08x)
+Testing collisions (low  32-bit) - Expected        668.7, actual    677 (1.01x) (9)
+Testing collisions (low  25-37 bits) - Worst is 36 bits: 44/41 (1.05x)
 Testing collisions (low  12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
 Testing collisions (low   8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit 56 - 0.070%
+Testing distribution - Worst bias is the 18-bit window at bit 89 - 0.073%
 
 
 Combination Hi-Lo Tests:
 Keyset 'Combination' - up to 6 blocks from a set of 15 - 12204240 keys
 Testing collisions (128-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      17339.3, actual  17187 (0.99x) (-152)
+Testing collisions (high 32-bit) - Expected      17339.3, actual  17203 (0.99x) (-136)
 Testing collisions (high 27-41 bits) - Worst is 41 bits: 42/33 (1.24x)
 Testing collisions (high 12-bit) - Expected   12200144.0, actual 12200144 (1.00x)
 Testing collisions (high  8-bit) - Expected   12203984.0, actual 12203984 (1.00x)
 Testing collisions (low  64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (low  32-bit) - Expected      17339.3, actual  17353 (1.00x) (14)
-Testing collisions (low  27-41 bits) - Worst is 34 bits: 4411/4334 (1.02x)
+Testing collisions (low  32-bit) - Expected      17339.3, actual  17354 (1.00x) (15)
+Testing collisions (low  27-41 bits) - Worst is 34 bits: 4416/4334 (1.02x)
 Testing collisions (low  12-bit) - Expected   12200144.0, actual 12200144 (1.00x)
 Testing collisions (low   8-bit) - Expected   12203984.0, actual 12203984 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 16 - 0.030%
+Testing distribution - Worst bias is the 20-bit window at bit 101 - 0.031%
 
 
 Combination 0x8000000 Tests:
@@ -295,10 +295,10 @@ Testing collisions (high 12-bit) - Expected     258046.0, actual 258046 (1.00x)
 Testing collisions (high  8-bit) - Expected     261886.0, actual 261886 (1.00x)
 Testing collisions (low  64-bit) - Expected          0.0, actual      0 (0.00x)
 Testing collisions (low  32-bit) - Expected          8.0, actual      6 (0.75x)
-Testing collisions (low  21-30 bits) - Worst is 24 bits: 2065/2047 (1.01x)
+Testing collisions (low  21-30 bits) - Worst is 24 bits: 2066/2047 (1.01x)
 Testing collisions (low  12-bit) - Expected     258046.0, actual 258046 (1.00x)
 Testing collisions (low   8-bit) - Expected     261886.0, actual 261886 (1.00x)
-Testing distribution - Worst bias is the 15-bit window at bit 120 - 0.310%
+Testing distribution - Worst bias is the 15-bit window at bit 120 - 0.311%
 
 
 Combination 0x0000001 Tests:
@@ -314,7 +314,7 @@ Testing collisions (low  32-bit) - Expected          8.0, actual      7 (0.88x)
 Testing collisions (low  21-30 bits) - Worst is 29 bits: 71/63 (1.11x)
 Testing collisions (low  12-bit) - Expected     258046.0, actual 258046 (1.00x)
 Testing collisions (low   8-bit) - Expected     261886.0, actual 261886 (1.00x)
-Testing distribution - Worst bias is the 15-bit window at bit 17 - 0.282%
+Testing distribution - Worst bias is the 15-bit window at bit 17 - 0.284%
 
 
 Combination 0x800000000000000 Tests:
@@ -378,7 +378,7 @@ Testing collisions (low  32-bit) - Expected          8.0, actual      8 (1.00x) 
 Testing collisions (low  21-30 bits) - Worst is 30 bits: 35/31 (1.09x)
 Testing collisions (low  12-bit) - Expected     258046.0, actual 258046 (1.00x)
 Testing collisions (low   8-bit) - Expected     261886.0, actual 261886 (1.00x)
-Testing distribution - Worst bias is the 15-bit window at bit 73 - 0.280%
+Testing distribution - Worst bias is the 15-bit window at bit 73 - 0.281%
 
 
 Combination 32-bytes [0-1] Tests:
@@ -634,16 +634,16 @@ Testing distribution - Worst bias is the 20-bit window at bit  2 - 0.075%
 Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
 Testing collisions (128-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      40347.8, actual  40564 (1.01x) (217)
-Testing collisions (high 27-42 bits) - Worst is 32 bits: 40564/40347 (1.01x)
+Testing collisions (high 32-bit) - Expected      40347.8, actual  40393 (1.00x) (46)
+Testing collisions (high 27-42 bits) - Worst is 39 bits: 327/315 (1.04x)
 Testing collisions (high 12-bit) - Expected   18612689.0, actual 18612689 (1.00x)
 Testing collisions (high  8-bit) - Expected   18616529.0, actual 18616529 (1.00x)
 Testing collisions (low  64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (low  32-bit) - Expected      40347.8, actual  40162 (1.00x) (-185)
-Testing collisions (low  27-42 bits) - Worst is 42 bits: 50/39 (1.27x)
+Testing collisions (low  32-bit) - Expected      40347.8, actual  40169 (1.00x) (-178)
+Testing collisions (low  27-42 bits) - Worst is 41 bits: 94/78 (1.19x)
 Testing collisions (low  12-bit) - Expected   18612689.0, actual 18612689 (1.00x)
 Testing collisions (low   8-bit) - Expected   18616529.0, actual 18616529 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit  0 - 0.025%
+Testing distribution - Worst bias is the 20-bit window at bit 100 - 0.022%
 
 
 [[[ Keyset 'Text' Tests ]]]
@@ -651,86 +651,86 @@ Testing distribution - Worst bias is the 20-bit window at bit  0 - 0.025%
 Keyset 'Text' - keys of form "FooXXXXBar" - 14776336 keys
 Testing collisions (128-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      25418.1, actual  25705 (1.01x) (287)
-Testing collisions (high 27-42 bits) - Worst is 42 bits: 29/24 (1.17x)
+Testing collisions (high 32-bit) - Expected      25418.1, actual  25070 (0.99x) (-348)
+Testing collisions (high 27-42 bits) - Worst is 34 bits: 6376/6354 (1.00x)
 Testing collisions (high 12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (high  8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
 Testing collisions (low  64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (low  32-bit) - Expected      25418.1, actual  25763 (1.01x) (345)
-Testing collisions (low  27-42 bits) - Worst is 40 bits: 109/99 (1.10x)
+Testing collisions (low  32-bit) - Expected      25418.1, actual  25466 (1.00x) (48)
+Testing collisions (low  27-42 bits) - Worst is 37 bits: 860/794 (1.08x)
 Testing collisions (low  12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (low   8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 43 - 0.027%
+Testing distribution - Worst bias is the 20-bit window at bit 88 - 0.028%
 
 Keyset 'Text' - keys of form "FooBarXXXX" - 14776336 keys
 Testing collisions (128-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      25418.1, actual  25587 (1.01x) (169)
-Testing collisions (high 27-42 bits) - Worst is 38 bits: 448/397 (1.13x)
+Testing collisions (high 32-bit) - Expected      25418.1, actual  25552 (1.01x) (134)
+Testing collisions (high 27-42 bits) - Worst is 38 bits: 425/397 (1.07x)
 Testing collisions (high 12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (high  8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
 Testing collisions (low  64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (low  32-bit) - Expected      25418.1, actual  25478 (1.00x) (60)
-Testing collisions (low  27-42 bits) - Worst is 37 bits: 811/794 (1.02x)
+Testing collisions (low  32-bit) - Expected      25418.1, actual  25489 (1.00x) (71)
+Testing collisions (low  27-42 bits) - Worst is 42 bits: 28/24 (1.13x)
 Testing collisions (low  12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (low   8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 46 - 0.023%
+Testing distribution - Worst bias is the 20-bit window at bit 70 - 0.030%
 
 Keyset 'Text' - keys of form "XXXXFooBar" - 14776336 keys
 Testing collisions (128-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      25418.1, actual  25572 (1.01x) (154)
-Testing collisions (high 27-42 bits) - Worst is 42 bits: 30/24 (1.21x)
+Testing collisions (high 32-bit) - Expected      25418.1, actual  25309 (1.00x) (-109)
+Testing collisions (high 27-42 bits) - Worst is 41 bits: 54/49 (1.09x)
 Testing collisions (high 12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (high  8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
 Testing collisions (low  64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (low  32-bit) - Expected      25418.1, actual  25340 (1.00x) (-78)
-Testing collisions (low  27-42 bits) - Worst is 36 bits: 1636/1588 (1.03x)
+Testing collisions (low  32-bit) - Expected      25418.1, actual  25376 (1.00x) (-42)
+Testing collisions (low  27-42 bits) - Worst is 41 bits: 54/49 (1.09x)
 Testing collisions (low  12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (low   8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 94 - 0.028%
+Testing distribution - Worst bias is the 20-bit window at bit 34 - 0.032%
 
 Keyset 'Words' - 4000000 random keys of len 6-16 from alnum charset
 Testing collisions (128-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1862.6, actual   1945 (1.04x) (83)
-Testing collisions (high 25-38 bits) - Worst is 35 bits: 257/232 (1.10x)
+Testing collisions (high 32-bit) - Expected       1862.6, actual   1861 (1.00x) (-1)
+Testing collisions (high 25-38 bits) - Worst is 34 bits: 506/465 (1.09x)
 Testing collisions (high 12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (high  8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
 Testing collisions (low  64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (low  32-bit) - Expected       1862.6, actual   1825 (0.98x)
-Testing collisions (low  25-38 bits) - Worst is 38 bits: 35/29 (1.20x)
+Testing collisions (low  32-bit) - Expected       1862.6, actual   1854 (1.00x) (-8)
+Testing collisions (low  25-38 bits) - Worst is 33 bits: 942/931 (1.01x)
 Testing collisions (low  12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (low   8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 24 - 0.070%
+Testing distribution - Worst bias is the 19-bit window at bit 64 - 0.064%
 
 Keyset 'Words' - 4000000 random keys of len 6-16 from password charset
 Testing collisions (128-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1862.6, actual   1876 (1.01x) (14)
-Testing collisions (high 25-38 bits) - Worst is 36 bits: 129/116 (1.11x)
+Testing collisions (high 32-bit) - Expected       1862.6, actual   1829 (0.98x) (-33)
+Testing collisions (high 25-38 bits) - Worst is 38 bits: 31/29 (1.07x)
 Testing collisions (high 12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (high  8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
 Testing collisions (low  64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (low  32-bit) - Expected       1862.6, actual   1843 (0.99x) (-19)
-Testing collisions (low  25-38 bits) - Worst is 31 bits: 3757/3725 (1.01x)
+Testing collisions (low  32-bit) - Expected       1862.6, actual   1841 (0.99x) (-21)
+Testing collisions (low  25-38 bits) - Worst is 29 bits: 14948/14901 (1.00x)
 Testing collisions (low  12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (low   8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 100 - 0.062%
+Testing distribution - Worst bias is the 19-bit window at bit 94 - 0.070%
 
 Keyset 'Words' - 167303 dict words
 Testing collisions (128-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected          3.3, actual      2 (0.61x)
-Testing collisions (high 21-29 bits) - Worst is 28 bits: 57/52 (1.09x)
+Testing collisions (high 32-bit) - Expected          3.3, actual      7 (2.15x) (4) !
+Testing collisions (high 21-29 bits) - Worst is 29 bits: 31/26 (1.19x)
 Testing collisions (high 12-bit) - Expected     163207.0, actual 163207 (1.00x)
 Testing collisions (high  8-bit) - Expected     167047.0, actual 167047 (1.00x)
 Testing collisions (low  64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (low  32-bit) - Expected          3.3, actual      3 (0.92x)
-Testing collisions (low  21-29 bits) - Worst is 27 bits: 113/104 (1.08x)
+Testing collisions (low  32-bit) - Expected          3.3, actual      2 (0.61x)
+Testing collisions (low  21-29 bits) - Worst is 23 bits: 1673/1668 (1.00x)
 Testing collisions (low  12-bit) - Expected     163207.0, actual 163207 (1.00x)
 Testing collisions (low   8-bit) - Expected     167047.0, actual 167047 (1.00x)
-Testing distribution - Worst bias is the 15-bit window at bit 91 - 0.543%
+Testing distribution - Worst bias is the 15-bit window at bit 62 - 0.356%
 
 
 [[[ Keyset 'Zeroes' Tests ]]]
@@ -747,7 +747,7 @@ Testing collisions (low  32-bit) - Expected          4.9, actual      5 (1.02x) 
 Testing collisions (low  21-29 bits) - Worst is 29 bits: 46/39 (1.18x)
 Testing collisions (low  12-bit) - Expected     200704.0, actual 200704 (1.00x)
 Testing collisions (low   8-bit) - Expected     204544.0, actual 204544 (1.00x)
-Testing distribution - Worst bias is the 15-bit window at bit 22 - 0.313%
+Testing distribution - Worst bias is the 15-bit window at bit 22 - 0.316%
 
 
 [[[ Keyset 'Seed' Tests ]]]
@@ -1656,17 +1656,17 @@ MomentChi2 for deriv b0 :   240.668
 Generating 33554432 random numbers : 
 Testing collisions (128-bit) - Expected    0.0, actual      0 (0.00x)
 Testing collisions (high 64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected     131072.0, actual 130579 (1.00x) (-492)
-Testing collisions (high 28-44 bits) - Worst is 40 bits: 534/511 (1.04x)
+Testing collisions (high 32-bit) - Expected     131072.0, actual 130631 (1.00x) (-440)
+Testing collisions (high 28-44 bits) - Worst is 39 bits: 1040/1023 (1.02x)
 Testing collisions (high 12-bit) - Expected   33550336.0, actual 33550336 (1.00x)
 Testing collisions (high  8-bit) - Expected   33554176.0, actual 33554176 (1.00x)
 Testing collisions (low  64-bit) - Expected          0.0, actual      0 (0.00x)
-Testing collisions (low  32-bit) - Expected     131072.0, actual 130088 (0.99x) (-983)
-Testing collisions (low  28-44 bits) - Worst is 44 bits: 35/31 (1.09x)
+Testing collisions (low  32-bit) - Expected     131072.0, actual 130783 (1.00x) (-288)
+Testing collisions (low  28-44 bits) - Worst is 44 bits: 42/31 (1.31x)
 Testing collisions (low  12-bit) - Expected   33550336.0, actual 33550336 (1.00x)
 Testing collisions (low   8-bit) - Expected   33554176.0, actual 33554176 (1.00x)
 
 
 Input vcode 0x00000001, Output vcode 0x00000001, Result vcode 0x00000001
-Verification value is 0x00000001 - Testing took -1627.465670 seconds
+Verification value is 0x00000001 - Testing took -1500.091551 seconds
 -------------------------------------------------------------------------------

--- a/smhasher/umash32.log
+++ b/smhasher/umash32.log
@@ -3,65 +3,65 @@
 
 [[[ Sanity Tests ]]]
 
-Verification value 0xD1F75869 ....... PASS
+Verification value 0x9CE5B1BC ....... PASS
 Running sanity check 1     .......... PASS
 Running AppendedZeroesTest .......... PASS
 
 [[[ Speed Tests ]]]
 
 Bulk speed test - 262144-byte keys
-Alignment  7 -  6.964 bytes/cycle - 19923.78 MiB/sec @ 3 ghz
-Alignment  6 -  5.614 bytes/cycle - 16061.97 MiB/sec @ 3 ghz
-Alignment  5 -  5.449 bytes/cycle - 15589.62 MiB/sec @ 3 ghz
-Alignment  4 -  8.698 bytes/cycle - 24884.46 MiB/sec @ 3 ghz
-Alignment  3 -  7.051 bytes/cycle - 20173.77 MiB/sec @ 3 ghz
-Alignment  2 -  8.629 bytes/cycle - 24688.89 MiB/sec @ 3 ghz
-Alignment  1 -  8.418 bytes/cycle - 24084.33 MiB/sec @ 3 ghz
-Alignment  0 -  8.712 bytes/cycle - 24926.28 MiB/sec @ 3 ghz
-Average      -  7.442 bytes/cycle - 21291.64 MiB/sec @ 3 ghz
+Alignment  7 - 11.651 bytes/cycle - 33334.82 MiB/sec @ 3 ghz
+Alignment  6 - 11.578 bytes/cycle - 33125.31 MiB/sec @ 3 ghz
+Alignment  5 - 11.458 bytes/cycle - 32782.68 MiB/sec @ 3 ghz
+Alignment  4 - 11.478 bytes/cycle - 32837.51 MiB/sec @ 3 ghz
+Alignment  3 - 11.411 bytes/cycle - 32647.57 MiB/sec @ 3 ghz
+Alignment  2 - 11.434 bytes/cycle - 32711.65 MiB/sec @ 3 ghz
+Alignment  1 - 11.340 bytes/cycle - 32442.76 MiB/sec @ 3 ghz
+Alignment  0 -  8.857 bytes/cycle - 25339.95 MiB/sec @ 3 ghz
+Average      - 11.151 bytes/cycle - 31902.78 MiB/sec @ 3 ghz
 
-Small key speed test -    1-byte keys -    20.02 cycles/hash
-Small key speed test -    2-byte keys -    21.66 cycles/hash
-Small key speed test -    3-byte keys -    23.60 cycles/hash
-Small key speed test -    4-byte keys -    20.15 cycles/hash
-Small key speed test -    5-byte keys -    27.53 cycles/hash
-Small key speed test -    6-byte keys -    28.00 cycles/hash
-Small key speed test -    7-byte keys -    27.40 cycles/hash
-Small key speed test -    8-byte keys -    25.85 cycles/hash
-Small key speed test -    9-byte keys -    40.87 cycles/hash
-Small key speed test -   10-byte keys -    43.00 cycles/hash
-Small key speed test -   11-byte keys -    42.89 cycles/hash
-Small key speed test -   12-byte keys -    42.23 cycles/hash
-Small key speed test -   13-byte keys -    43.44 cycles/hash
-Small key speed test -   14-byte keys -    43.33 cycles/hash
-Small key speed test -   15-byte keys -    41.73 cycles/hash
-Small key speed test -   16-byte keys -    42.21 cycles/hash
-Small key speed test -   17-byte keys -    44.87 cycles/hash
-Small key speed test -   18-byte keys -    44.64 cycles/hash
-Small key speed test -   19-byte keys -    44.33 cycles/hash
-Small key speed test -   20-byte keys -    43.77 cycles/hash
-Small key speed test -   21-byte keys -    41.24 cycles/hash
-Small key speed test -   22-byte keys -    41.27 cycles/hash
-Small key speed test -   23-byte keys -    43.86 cycles/hash
-Small key speed test -   24-byte keys -    46.30 cycles/hash
-Small key speed test -   25-byte keys -    45.16 cycles/hash
-Small key speed test -   26-byte keys -    45.27 cycles/hash
-Small key speed test -   27-byte keys -    44.57 cycles/hash
-Small key speed test -   28-byte keys -    46.08 cycles/hash
-Small key speed test -   29-byte keys -    46.09 cycles/hash
-Small key speed test -   30-byte keys -    45.75 cycles/hash
-Small key speed test -   31-byte keys -    44.54 cycles/hash
-Average                                    38.763 cycles/hash
+Small key speed test -    1-byte keys -    20.95 cycles/hash
+Small key speed test -    2-byte keys -    15.01 cycles/hash
+Small key speed test -    3-byte keys -    15.70 cycles/hash
+Small key speed test -    4-byte keys -    14.26 cycles/hash
+Small key speed test -    5-byte keys -    19.91 cycles/hash
+Small key speed test -    6-byte keys -    20.76 cycles/hash
+Small key speed test -    7-byte keys -    19.93 cycles/hash
+Small key speed test -    8-byte keys -    14.97 cycles/hash
+Small key speed test -    9-byte keys -    37.15 cycles/hash
+Small key speed test -   10-byte keys -    40.66 cycles/hash
+Small key speed test -   11-byte keys -    41.61 cycles/hash
+Small key speed test -   12-byte keys -    41.60 cycles/hash
+Small key speed test -   13-byte keys -    39.89 cycles/hash
+Small key speed test -   14-byte keys -    38.13 cycles/hash
+Small key speed test -   15-byte keys -    37.40 cycles/hash
+Small key speed test -   16-byte keys -    37.11 cycles/hash
+Small key speed test -   17-byte keys -    45.66 cycles/hash
+Small key speed test -   18-byte keys -    46.15 cycles/hash
+Small key speed test -   19-byte keys -    43.01 cycles/hash
+Small key speed test -   20-byte keys -    44.12 cycles/hash
+Small key speed test -   21-byte keys -    43.55 cycles/hash
+Small key speed test -   22-byte keys -    40.23 cycles/hash
+Small key speed test -   23-byte keys -    39.99 cycles/hash
+Small key speed test -   24-byte keys -    39.93 cycles/hash
+Small key speed test -   25-byte keys -    39.64 cycles/hash
+Small key speed test -   26-byte keys -    39.97 cycles/hash
+Small key speed test -   27-byte keys -    39.99 cycles/hash
+Small key speed test -   28-byte keys -    40.22 cycles/hash
+Small key speed test -   29-byte keys -    39.97 cycles/hash
+Small key speed test -   30-byte keys -    39.98 cycles/hash
+Small key speed test -   31-byte keys -    40.03 cycles/hash
+Average                                    34.757 cycles/hash
 
 [[[ 'Hashmap' Speed Tests ]]]
 
 std::unordered_map
-Init std HashMapTest:     754.556 cycles/op (167303 inserts, 1% deletions)
-Running std HashMapTest:  456.116 cycles/op (30.4 stdv)
+Init std HashMapTest:     657.705 cycles/op (167303 inserts, 1% deletions)
+Running std HashMapTest:  437.831 cycles/op (33.4 stdv)
 
 greg7mdp/parallel-hashmap
-Init fast HashMapTest:    368.226 cycles/op (167303 inserts, 1% deletions)
-Running fast HashMapTest: 350.040 cycles/op (19.7 stdv)  ....... PASS
+Init fast HashMapTest:    312.482 cycles/op (167303 inserts, 1% deletions)
+Running fast HashMapTest: 297.898 cycles/op (16.3 stdv)  ....... PASS
 
 [[[ Avalanche Tests ]]]
 
@@ -71,11 +71,11 @@ Testing   40-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.646000%
 Testing   48-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.603333%
 Testing   56-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.614000%
 Testing   64-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.688667%
-Testing   72-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.621333%
-Testing   80-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.757333%
-Testing   96-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.620000%
-Testing  112-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.783333%
-Testing  128-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.688000%
+Testing   72-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.620667%
+Testing   80-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.638000%
+Testing   96-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.675333%
+Testing  112-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.684667%
+Testing  128-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.626667%
 Testing  160-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.660000%
 Testing  512-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.696000%
 Testing 1024-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.774667%
@@ -141,20 +141,20 @@ Testing collisions (low   8-bit) - Expected    8303377.0, actual 8303377 (1.00x)
 Testing distribution - Worst bias is the 20-bit window at bit 10 - 0.038%
 
 Keyset 'Sparse' - 72-bit keys with up to 5 bits set - 15082603 keys
-Testing collisions ( 32-bit) - Expected 26482.7, actual  26601 (1.00x) (119)
+Testing collisions ( 32-bit) - Expected 26482.7, actual  26163 (0.99x) (-319)
 Testing collisions (high 12-bit) - Expected   15078507.0, actual 15078507 (1.00x)
 Testing collisions (high  8-bit) - Expected   15082347.0, actual 15082347 (1.00x)
 Testing collisions (low  12-bit) - Expected   15078507.0, actual 15078507 (1.00x)
 Testing collisions (low   8-bit) - Expected   15082347.0, actual 15082347 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit  5 - 0.024%
+Testing distribution - Worst bias is the 20-bit window at bit 12 - 0.015%
 
 Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
-Testing collisions ( 32-bit) - Expected 1401.3, actual   1471 (1.05x) (70)
+Testing collisions ( 32-bit) - Expected 1401.3, actual   1346 (0.96x)
 Testing collisions (high 12-bit) - Expected    3465401.0, actual 3465401 (1.00x)
 Testing collisions (high  8-bit) - Expected    3469241.0, actual 3469241 (1.00x)
 Testing collisions (low  12-bit) - Expected    3465401.0, actual 3465401 (1.00x)
 Testing collisions (low   8-bit) - Expected    3469241.0, actual 3469241 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 26 - 0.033%
+Testing distribution - Worst bias is the 19-bit window at bit 10 - 0.055%
 
 Keyset 'Sparse' - 160-bit keys with up to 4 bits set - 26977161 keys
 Testing collisions ( 32-bit) - Expected 84723.3, actual  84614 (1.00x) (-109)
@@ -201,27 +201,27 @@ Testing distribution - Worst bias is the 18-bit window at bit  7 - 0.059%
 
 Combination Lowbits Tests:
 Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
-Testing collisions ( 32-bit) - Expected  668.7, actual    717 (1.07x) (49)
+Testing collisions ( 32-bit) - Expected  668.7, actual    720 (1.08x) (52)
 Testing collisions (high 12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
 Testing collisions (high  8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
 Testing collisions (low  12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
 Testing collisions (low   8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit 30 - 0.056%
+Testing distribution - Worst bias is the 18-bit window at bit 30 - 0.054%
 
 
 Combination Highbits Tests
 Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
-Testing collisions ( 32-bit) - Expected  668.7, actual    675 (1.01x) (7)
+Testing collisions ( 32-bit) - Expected  668.7, actual    677 (1.01x) (9)
 Testing collisions (high 12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
 Testing collisions (high  8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
 Testing collisions (low  12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
 Testing collisions (low   8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
-Testing distribution - Worst bias is the 17-bit window at bit 12 - 0.052%
+Testing distribution - Worst bias is the 17-bit window at bit 12 - 0.051%
 
 
 Combination Hi-Lo Tests:
 Keyset 'Combination' - up to 6 blocks from a set of 15 - 12204240 keys
-Testing collisions ( 32-bit) - Expected 17339.3, actual  17353 (1.00x) (14)
+Testing collisions ( 32-bit) - Expected 17339.3, actual  17354 (1.00x) (15)
 Testing collisions (high 12-bit) - Expected   12200144.0, actual 12200144 (1.00x)
 Testing collisions (high  8-bit) - Expected   12203984.0, actual 12203984 (1.00x)
 Testing collisions (low  12-bit) - Expected   12200144.0, actual 12200144 (1.00x)
@@ -352,79 +352,79 @@ Testing distribution - Worst bias is the 20-bit window at bit 17 - 0.058%
 [[[ Keyset 'Window' Tests ]]]
 
 Keyset 'Window' -  72-bit key,  20-bit window - 72 tests, 1048576 keys per test
-Window at   0 - Testing collisions ( 32-bit) - Expected  128.0, actual    131 (1.02x) (4)
-Window at   1 - Testing collisions ( 32-bit) - Expected  128.0, actual    127 (0.99x)
-Window at   2 - Testing collisions ( 32-bit) - Expected  128.0, actual    123 (0.96x)
-Window at   3 - Testing collisions ( 32-bit) - Expected  128.0, actual    135 (1.05x) (8)
-Window at   4 - Testing collisions ( 32-bit) - Expected  128.0, actual    128 (1.00x) (1)
-Window at   5 - Testing collisions ( 32-bit) - Expected  128.0, actual    126 (0.98x) (-1)
-Window at   6 - Testing collisions ( 32-bit) - Expected  128.0, actual    137 (1.07x) (10)
-Window at   7 - Testing collisions ( 32-bit) - Expected  128.0, actual    131 (1.02x) (4)
-Window at   8 - Testing collisions ( 32-bit) - Expected  128.0, actual    128 (1.00x) (1)
-Window at   9 - Testing collisions ( 32-bit) - Expected  128.0, actual    127 (0.99x)
-Window at  10 - Testing collisions ( 32-bit) - Expected  128.0, actual    136 (1.06x) (9)
-Window at  11 - Testing collisions ( 32-bit) - Expected  128.0, actual    124 (0.97x)
-Window at  12 - Testing collisions ( 32-bit) - Expected  128.0, actual    121 (0.95x)
-Window at  13 - Testing collisions ( 32-bit) - Expected  128.0, actual    131 (1.02x) (4)
-Window at  14 - Testing collisions ( 32-bit) - Expected  128.0, actual    123 (0.96x)
-Window at  15 - Testing collisions ( 32-bit) - Expected  128.0, actual    130 (1.02x) (3)
-Window at  16 - Testing collisions ( 32-bit) - Expected  128.0, actual    121 (0.95x)
-Window at  17 - Testing collisions ( 32-bit) - Expected  128.0, actual    124 (0.97x)
-Window at  18 - Testing collisions ( 32-bit) - Expected  128.0, actual    131 (1.02x) (4)
-Window at  19 - Testing collisions ( 32-bit) - Expected  128.0, actual    131 (1.02x) (4)
-Window at  20 - Testing collisions ( 32-bit) - Expected  128.0, actual    108 (0.84x)
-Window at  21 - Testing collisions ( 32-bit) - Expected  128.0, actual    130 (1.02x) (3)
-Window at  22 - Testing collisions ( 32-bit) - Expected  128.0, actual    131 (1.02x) (4)
-Window at  23 - Testing collisions ( 32-bit) - Expected  128.0, actual    127 (0.99x)
-Window at  24 - Testing collisions ( 32-bit) - Expected  128.0, actual    139 (1.09x) (12)
-Window at  25 - Testing collisions ( 32-bit) - Expected  128.0, actual    128 (1.00x) (1)
-Window at  26 - Testing collisions ( 32-bit) - Expected  128.0, actual    128 (1.00x) (1)
-Window at  27 - Testing collisions ( 32-bit) - Expected  128.0, actual    130 (1.02x) (3)
+Window at   0 - Testing collisions ( 32-bit) - Expected  128.0, actual    117 (0.91x)
+Window at   1 - Testing collisions ( 32-bit) - Expected  128.0, actual    121 (0.95x)
+Window at   2 - Testing collisions ( 32-bit) - Expected  128.0, actual    141 (1.10x) (14)
+Window at   3 - Testing collisions ( 32-bit) - Expected  128.0, actual    130 (1.02x) (3)
+Window at   4 - Testing collisions ( 32-bit) - Expected  128.0, actual    122 (0.95x)
+Window at   5 - Testing collisions ( 32-bit) - Expected  128.0, actual    119 (0.93x)
+Window at   6 - Testing collisions ( 32-bit) - Expected  128.0, actual    115 (0.90x)
+Window at   7 - Testing collisions ( 32-bit) - Expected  128.0, actual    119 (0.93x)
+Window at   8 - Testing collisions ( 32-bit) - Expected  128.0, actual    125 (0.98x)
+Window at   9 - Testing collisions ( 32-bit) - Expected  128.0, actual    123 (0.96x)
+Window at  10 - Testing collisions ( 32-bit) - Expected  128.0, actual    137 (1.07x) (10)
+Window at  11 - Testing collisions ( 32-bit) - Expected  128.0, actual    121 (0.95x)
+Window at  12 - Testing collisions ( 32-bit) - Expected  128.0, actual    120 (0.94x)
+Window at  13 - Testing collisions ( 32-bit) - Expected  128.0, actual    118 (0.92x)
+Window at  14 - Testing collisions ( 32-bit) - Expected  128.0, actual    134 (1.05x) (7)
+Window at  15 - Testing collisions ( 32-bit) - Expected  128.0, actual    121 (0.95x)
+Window at  16 - Testing collisions ( 32-bit) - Expected  128.0, actual    117 (0.91x)
+Window at  17 - Testing collisions ( 32-bit) - Expected  128.0, actual    134 (1.05x) (7)
+Window at  18 - Testing collisions ( 32-bit) - Expected  128.0, actual    125 (0.98x)
+Window at  19 - Testing collisions ( 32-bit) - Expected  128.0, actual    135 (1.05x) (8)
+Window at  20 - Testing collisions ( 32-bit) - Expected  128.0, actual    142 (1.11x) (15)
+Window at  21 - Testing collisions ( 32-bit) - Expected  128.0, actual    126 (0.98x) (-1)
+Window at  22 - Testing collisions ( 32-bit) - Expected  128.0, actual    108 (0.84x)
+Window at  23 - Testing collisions ( 32-bit) - Expected  128.0, actual    114 (0.89x)
+Window at  24 - Testing collisions ( 32-bit) - Expected  128.0, actual    112 (0.88x)
+Window at  25 - Testing collisions ( 32-bit) - Expected  128.0, actual    119 (0.93x)
+Window at  26 - Testing collisions ( 32-bit) - Expected  128.0, actual    124 (0.97x)
+Window at  27 - Testing collisions ( 32-bit) - Expected  128.0, actual    137 (1.07x) (10)
 Window at  28 - Testing collisions ( 32-bit) - Expected  128.0, actual    122 (0.95x)
-Window at  29 - Testing collisions ( 32-bit) - Expected  128.0, actual    131 (1.02x) (4)
-Window at  30 - Testing collisions ( 32-bit) - Expected  128.0, actual    135 (1.05x) (8)
-Window at  31 - Testing collisions ( 32-bit) - Expected  128.0, actual    120 (0.94x)
-Window at  32 - Testing collisions ( 32-bit) - Expected  128.0, actual    115 (0.90x)
-Window at  33 - Testing collisions ( 32-bit) - Expected  128.0, actual    131 (1.02x) (4)
-Window at  34 - Testing collisions ( 32-bit) - Expected  128.0, actual    122 (0.95x)
-Window at  35 - Testing collisions ( 32-bit) - Expected  128.0, actual    117 (0.91x)
-Window at  36 - Testing collisions ( 32-bit) - Expected  128.0, actual    132 (1.03x) (5)
-Window at  37 - Testing collisions ( 32-bit) - Expected  128.0, actual    133 (1.04x) (6)
-Window at  38 - Testing collisions ( 32-bit) - Expected  128.0, actual    136 (1.06x) (9)
-Window at  39 - Testing collisions ( 32-bit) - Expected  128.0, actual    141 (1.10x) (14)
+Window at  29 - Testing collisions ( 32-bit) - Expected  128.0, actual    134 (1.05x) (7)
+Window at  30 - Testing collisions ( 32-bit) - Expected  128.0, actual    113 (0.88x)
+Window at  31 - Testing collisions ( 32-bit) - Expected  128.0, actual    123 (0.96x)
+Window at  32 - Testing collisions ( 32-bit) - Expected  128.0, actual    137 (1.07x) (10)
+Window at  33 - Testing collisions ( 32-bit) - Expected  128.0, actual    117 (0.91x)
+Window at  34 - Testing collisions ( 32-bit) - Expected  128.0, actual    125 (0.98x)
+Window at  35 - Testing collisions ( 32-bit) - Expected  128.0, actual    113 (0.88x)
+Window at  36 - Testing collisions ( 32-bit) - Expected  128.0, actual    149 (1.16x) (22)
+Window at  37 - Testing collisions ( 32-bit) - Expected  128.0, actual    141 (1.10x) (14)
+Window at  38 - Testing collisions ( 32-bit) - Expected  128.0, actual    130 (1.02x) (3)
+Window at  39 - Testing collisions ( 32-bit) - Expected  128.0, actual    112 (0.88x)
 Window at  40 - Testing collisions ( 32-bit) - Expected  128.0, actual    129 (1.01x) (2)
-Window at  41 - Testing collisions ( 32-bit) - Expected  128.0, actual    145 (1.13x) (18)
-Window at  42 - Testing collisions ( 32-bit) - Expected  128.0, actual    140 (1.09x) (13)
-Window at  43 - Testing collisions ( 32-bit) - Expected  128.0, actual    145 (1.13x) (18)
+Window at  41 - Testing collisions ( 32-bit) - Expected  128.0, actual    126 (0.98x) (-1)
+Window at  42 - Testing collisions ( 32-bit) - Expected  128.0, actual    118 (0.92x)
+Window at  43 - Testing collisions ( 32-bit) - Expected  128.0, actual    139 (1.09x) (12)
 Window at  44 - Testing collisions ( 32-bit) - Expected  128.0, actual    126 (0.98x) (-1)
-Window at  45 - Testing collisions ( 32-bit) - Expected  128.0, actual    140 (1.09x) (13)
-Window at  46 - Testing collisions ( 32-bit) - Expected  128.0, actual    130 (1.02x) (3)
-Window at  47 - Testing collisions ( 32-bit) - Expected  128.0, actual    136 (1.06x) (9)
-Window at  48 - Testing collisions ( 32-bit) - Expected  128.0, actual    138 (1.08x) (11)
-Window at  49 - Testing collisions ( 32-bit) - Expected  128.0, actual    150 (1.17x) (23)
-Window at  50 - Testing collisions ( 32-bit) - Expected  128.0, actual    127 (0.99x)
-Window at  51 - Testing collisions ( 32-bit) - Expected  128.0, actual     98 (0.77x)
-Window at  52 - Testing collisions ( 32-bit) - Expected  128.0, actual    101 (0.79x)
-Window at  53 - Testing collisions ( 32-bit) - Expected  128.0, actual    117 (0.91x)
-Window at  54 - Testing collisions ( 32-bit) - Expected  128.0, actual    123 (0.96x)
-Window at  55 - Testing collisions ( 32-bit) - Expected  128.0, actual    121 (0.95x)
-Window at  56 - Testing collisions ( 32-bit) - Expected  128.0, actual    111 (0.87x)
-Window at  57 - Testing collisions ( 32-bit) - Expected  128.0, actual    122 (0.95x)
-Window at  58 - Testing collisions ( 32-bit) - Expected  128.0, actual    121 (0.95x)
-Window at  59 - Testing collisions ( 32-bit) - Expected  128.0, actual    117 (0.91x)
-Window at  60 - Testing collisions ( 32-bit) - Expected  128.0, actual    136 (1.06x) (9)
-Window at  61 - Testing collisions ( 32-bit) - Expected  128.0, actual    144 (1.13x) (17)
-Window at  62 - Testing collisions ( 32-bit) - Expected  128.0, actual    113 (0.88x)
-Window at  63 - Testing collisions ( 32-bit) - Expected  128.0, actual    129 (1.01x) (2)
-Window at  64 - Testing collisions ( 32-bit) - Expected  128.0, actual    132 (1.03x) (5)
-Window at  65 - Testing collisions ( 32-bit) - Expected  128.0, actual    110 (0.86x)
-Window at  66 - Testing collisions ( 32-bit) - Expected  128.0, actual    124 (0.97x)
-Window at  67 - Testing collisions ( 32-bit) - Expected  128.0, actual    128 (1.00x) (1)
-Window at  68 - Testing collisions ( 32-bit) - Expected  128.0, actual    137 (1.07x) (10)
-Window at  69 - Testing collisions ( 32-bit) - Expected  128.0, actual    145 (1.13x) (18)
-Window at  70 - Testing collisions ( 32-bit) - Expected  128.0, actual    110 (0.86x)
-Window at  71 - Testing collisions ( 32-bit) - Expected  128.0, actual    122 (0.95x)
-Window at  72 - Testing collisions ( 32-bit) - Expected  128.0, actual    131 (1.02x) (4)
+Window at  45 - Testing collisions ( 32-bit) - Expected  128.0, actual    101 (0.79x)
+Window at  46 - Testing collisions ( 32-bit) - Expected  128.0, actual    119 (0.93x)
+Window at  47 - Testing collisions ( 32-bit) - Expected  128.0, actual    127 (0.99x)
+Window at  48 - Testing collisions ( 32-bit) - Expected  128.0, actual    142 (1.11x) (15)
+Window at  49 - Testing collisions ( 32-bit) - Expected  128.0, actual    135 (1.05x) (8)
+Window at  50 - Testing collisions ( 32-bit) - Expected  128.0, actual    148 (1.16x) (21)
+Window at  51 - Testing collisions ( 32-bit) - Expected  128.0, actual    123 (0.96x)
+Window at  52 - Testing collisions ( 32-bit) - Expected  128.0, actual    131 (1.02x) (4)
+Window at  53 - Testing collisions ( 32-bit) - Expected  128.0, actual    138 (1.08x) (11)
+Window at  54 - Testing collisions ( 32-bit) - Expected  128.0, actual    137 (1.07x) (10)
+Window at  55 - Testing collisions ( 32-bit) - Expected  128.0, actual    134 (1.05x) (7)
+Window at  56 - Testing collisions ( 32-bit) - Expected  128.0, actual    141 (1.10x) (14)
+Window at  57 - Testing collisions ( 32-bit) - Expected  128.0, actual    138 (1.08x) (11)
+Window at  58 - Testing collisions ( 32-bit) - Expected  128.0, actual    134 (1.05x) (7)
+Window at  59 - Testing collisions ( 32-bit) - Expected  128.0, actual    115 (0.90x)
+Window at  60 - Testing collisions ( 32-bit) - Expected  128.0, actual    141 (1.10x) (14)
+Window at  61 - Testing collisions ( 32-bit) - Expected  128.0, actual    126 (0.98x) (-1)
+Window at  62 - Testing collisions ( 32-bit) - Expected  128.0, actual    132 (1.03x) (5)
+Window at  63 - Testing collisions ( 32-bit) - Expected  128.0, actual    119 (0.93x)
+Window at  64 - Testing collisions ( 32-bit) - Expected  128.0, actual    129 (1.01x) (2)
+Window at  65 - Testing collisions ( 32-bit) - Expected  128.0, actual    134 (1.05x) (7)
+Window at  66 - Testing collisions ( 32-bit) - Expected  128.0, actual    123 (0.96x)
+Window at  67 - Testing collisions ( 32-bit) - Expected  128.0, actual    115 (0.90x)
+Window at  68 - Testing collisions ( 32-bit) - Expected  128.0, actual    119 (0.93x)
+Window at  69 - Testing collisions ( 32-bit) - Expected  128.0, actual    135 (1.05x) (8)
+Window at  70 - Testing collisions ( 32-bit) - Expected  128.0, actual    138 (1.08x) (11)
+Window at  71 - Testing collisions ( 32-bit) - Expected  128.0, actual    130 (1.02x) (3)
+Window at  72 - Testing collisions ( 32-bit) - Expected  128.0, actual    117 (0.91x)
 
 [[[ Keyset 'Cyclic' Tests ]]]
 
@@ -496,89 +496,89 @@ Testing collisions (low   8-bit) - Expected    5470769.0, actual 5470769 (1.00x)
 Testing distribution - Worst bias is the 20-bit window at bit  2 - 0.075%
 
 Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
-Testing collisions ( 32-bit) - Expected 40347.8, actual  40162 (1.00x) (-185)
+Testing collisions ( 32-bit) - Expected 40347.8, actual  40169 (1.00x) (-178)
 Testing collisions (high 12-bit) - Expected   18612689.0, actual 18612689 (1.00x)
 Testing collisions (high  8-bit) - Expected   18616529.0, actual 18616529 (1.00x)
 Testing collisions (low  12-bit) - Expected   18612689.0, actual 18612689 (1.00x)
 Testing collisions (low   8-bit) - Expected   18616529.0, actual 18616529 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit  0 - 0.025%
+Testing distribution - Worst bias is the 20-bit window at bit  7 - 0.018%
 
 Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
-Testing collisions ( 32-bit) - Expected 227963.2, actual 226937 (1.00x) (-1026)
+Testing collisions ( 32-bit) - Expected 227963.2, actual 227637 (1.00x) (-326)
 Testing collisions (high 12-bit) - Expected   44247329.0, actual 44247329 (1.00x)
 Testing collisions (high  8-bit) - Expected   44251169.0, actual 44251169 (1.00x)
 Testing collisions (low  12-bit) - Expected   44247329.0, actual 44247329 (1.00x)
 Testing collisions (low   8-bit) - Expected   44251169.0, actual 44251169 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit  4 - 0.005%
+Testing distribution - Worst bias is the 20-bit window at bit 13 - 0.008%
 
 Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
-Testing collisions ( 32-bit) - Expected 871784.7, actual 866685 (0.99x) (-5099)
+Testing collisions ( 32-bit) - Expected 871784.7, actual 867201 (0.99x) (-4583)
 Testing collisions (high 12-bit) - Expected   86532449.0, actual 86532449 (1.00x)
 Testing collisions (high  8-bit) - Expected   86536289.0, actual 86536289 (1.00x)
 Testing collisions (low  12-bit) - Expected   86532449.0, actual 86532449 (1.00x)
 Testing collisions (low   8-bit) - Expected   86536289.0, actual 86536289 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 15 - 0.003%
+Testing distribution - Worst bias is the 19-bit window at bit  5 - 0.003%
 
 Keyset 'TwoBytes' - up-to-24-byte keys, 149633745 total keys
-Testing collisions ( 32-bit) - Expected 2606569.0, actual 2576670 (0.99x) (-29899)
+Testing collisions ( 32-bit) - Expected 2606569.0, actual 2579139 (0.99x) (-27430)
 Testing collisions (high 12-bit) - Expected  149629649.0, actual 149629649 (1.00x)
 Testing collisions (high  8-bit) - Expected  149633489.0, actual 149633489 (1.00x)
 Testing collisions (low  12-bit) - Expected  149629649.0, actual 149629649 (1.00x)
 Testing collisions (low   8-bit) - Expected  149633489.0, actual 149633489 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 19 - 0.003%
+Testing distribution - Worst bias is the 19-bit window at bit  9 - 0.001%
 
 
 [[[ Keyset 'Text' Tests ]]]
 
 Keyset 'Text' - keys of form "FooXXXXBar" - 14776336 keys
-Testing collisions ( 32-bit) - Expected 25418.1, actual  25763 (1.01x) (345)
+Testing collisions ( 32-bit) - Expected 25418.1, actual  25466 (1.00x) (48)
 Testing collisions (high 12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (high  8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
 Testing collisions (low  12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (low   8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 17 - 0.019%
+Testing distribution - Worst bias is the 20-bit window at bit 23 - 0.020%
 
 Keyset 'Text' - keys of form "FooBarXXXX" - 14776336 keys
-Testing collisions ( 32-bit) - Expected 25418.1, actual  25478 (1.00x) (60)
+Testing collisions ( 32-bit) - Expected 25418.1, actual  25489 (1.00x) (71)
 Testing collisions (high 12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (high  8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
 Testing collisions (low  12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (low   8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 28 - 0.026%
+Testing distribution - Worst bias is the 20-bit window at bit 11 - 0.027%
 
 Keyset 'Text' - keys of form "XXXXFooBar" - 14776336 keys
-Testing collisions ( 32-bit) - Expected 25418.1, actual  25340 (1.00x) (-78)
+Testing collisions ( 32-bit) - Expected 25418.1, actual  25376 (1.00x) (-42)
 Testing collisions (high 12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (high  8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
 Testing collisions (low  12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (low   8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 30 - 0.018%
+Testing distribution - Worst bias is the 20-bit window at bit 12 - 0.011%
 
 Keyset 'Words' - 4000000 random keys of len 6-16 from alnum charset
-Testing collisions ( 32-bit) - Expected 1862.6, actual   1825 (0.98x)
+Testing collisions ( 32-bit) - Expected 1862.6, actual   1854 (1.00x) (-8)
 Testing collisions (high 12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (high  8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
 Testing collisions (low  12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (low   8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 25 - 0.062%
+Testing distribution - Worst bias is the 19-bit window at bit 19 - 0.049%
 
 Keyset 'Words' - 4000000 random keys of len 6-16 from password charset
-Testing collisions ( 32-bit) - Expected 1862.6, actual   1843 (0.99x) (-19)
+Testing collisions ( 32-bit) - Expected 1862.6, actual   1841 (0.99x) (-21)
 Testing collisions (high 12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (high  8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
 Testing collisions (low  12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (low   8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 13 - 0.036%
+Testing distribution - Worst bias is the 19-bit window at bit  4 - 0.048%
 
 Keyset 'Words' - 167303 dict words
-Testing collisions ( 32-bit) - Expected    3.3, actual      3 (0.92x)
-Testing collisions (high 21-29 bits) - Worst is 29 bits: 35/26 (1.34x)
+Testing collisions ( 32-bit) - Expected    3.3, actual      2 (0.61x)
+Testing collisions (high 21-29 bits) - Worst is 26 bits: 227/208 (1.09x)
 Testing collisions (high 12-bit) - Expected     163207.0, actual 163207 (1.00x)
 Testing collisions (high  8-bit) - Expected     167047.0, actual 167047 (1.00x)
-Testing collisions (low  21-29 bits) - Worst is 27 bits: 113/104 (1.08x)
+Testing collisions (low  21-29 bits) - Worst is 23 bits: 1673/1668 (1.00x)
 Testing collisions (low  12-bit) - Expected     163207.0, actual 163207 (1.00x)
 Testing collisions (low   8-bit) - Expected     167047.0, actual 167047 (1.00x)
-Testing distribution - Worst bias is the 15-bit window at bit  4 - 0.189%
+Testing distribution - Worst bias is the 15-bit window at bit  8 - 0.161%
 
 
 [[[ Keyset 'Zeroes' Tests ]]]
@@ -591,7 +591,7 @@ Testing collisions (high  8-bit) - Expected     204544.0, actual 204544 (1.00x)
 Testing collisions (low  21-29 bits) - Worst is 29 bits: 46/39 (1.18x)
 Testing collisions (low  12-bit) - Expected     200704.0, actual 200704 (1.00x)
 Testing collisions (low   8-bit) - Expected     204544.0, actual 204544 (1.00x)
-Testing distribution - Worst bias is the 15-bit window at bit 12 - 0.282%
+Testing distribution - Worst bias is the 15-bit window at bit 12 - 0.285%
 
 
 [[[ Keyset 'Seed' Tests ]]]
@@ -623,7 +623,7 @@ Testing 8303632 up-to-5-bit differentials in 64-bit keys -> 32 bit hashes.
 
 Testing 11017632 up-to-4-bit differentials in 128-bit keys -> 32 bit hashes.
 1000 reps, 11017632000 total tests, expecting 2.57 random collisions..........
-3 total collisions, of which 3 single collisions were ignored
+4 total collisions, of which 4 single collisions were ignored
 
 Testing 2796416 up-to-3-bit differentials in 256-bit keys -> 32 bit hashes.
 1000 reps, 2796416000 total tests, expecting 0.65 random collisions..........
@@ -1105,5 +1105,5 @@ The PRNG test is designed for hashes >= 64-bit
 
 
 Input vcode 0x00000001, Output vcode 0x00000001, Result vcode 0x00000001
-Verification value is 0x00000001 - Testing took 1469.229982 seconds
+Verification value is 0x00000001 - Testing took 1366.880212 seconds
 -------------------------------------------------------------------------------

--- a/smhasher/umash32_hi.log
+++ b/smhasher/umash32_hi.log
@@ -3,65 +3,65 @@
 
 [[[ Sanity Tests ]]]
 
-Verification value 0x4AD8D0B1 ....... PASS
+Verification value 0x54602133 ....... PASS
 Running sanity check 1     .......... PASS
 Running AppendedZeroesTest .......... PASS
 
 [[[ Speed Tests ]]]
 
 Bulk speed test - 262144-byte keys
-Alignment  7 -  5.589 bytes/cycle - 15988.91 MiB/sec @ 3 ghz
-Alignment  6 -  6.528 bytes/cycle - 18676.93 MiB/sec @ 3 ghz
-Alignment  5 -  6.239 bytes/cycle - 17848.72 MiB/sec @ 3 ghz
-Alignment  4 -  8.622 bytes/cycle - 24667.89 MiB/sec @ 3 ghz
-Alignment  3 -  6.687 bytes/cycle - 19130.40 MiB/sec @ 3 ghz
-Alignment  2 -  6.733 bytes/cycle - 19263.89 MiB/sec @ 3 ghz
-Alignment  1 -  5.916 bytes/cycle - 16924.45 MiB/sec @ 3 ghz
-Alignment  0 -  7.238 bytes/cycle - 20707.36 MiB/sec @ 3 ghz
-Average      -  6.694 bytes/cycle - 19151.07 MiB/sec @ 3 ghz
+Alignment  7 -  7.815 bytes/cycle - 22358.68 MiB/sec @ 3 ghz
+Alignment  6 -  8.452 bytes/cycle - 24181.36 MiB/sec @ 3 ghz
+Alignment  5 -  7.904 bytes/cycle - 22613.53 MiB/sec @ 3 ghz
+Alignment  4 -  7.835 bytes/cycle - 22415.22 MiB/sec @ 3 ghz
+Alignment  3 -  7.888 bytes/cycle - 22567.36 MiB/sec @ 3 ghz
+Alignment  2 - 11.509 bytes/cycle - 32927.72 MiB/sec @ 3 ghz
+Alignment  1 - 11.495 bytes/cycle - 32886.89 MiB/sec @ 3 ghz
+Alignment  0 -  7.980 bytes/cycle - 22829.61 MiB/sec @ 3 ghz
+Average      -  8.860 bytes/cycle - 25347.55 MiB/sec @ 3 ghz
 
-Small key speed test -    1-byte keys -    23.34 cycles/hash
-Small key speed test -    2-byte keys -    18.00 cycles/hash
-Small key speed test -    3-byte keys -    19.98 cycles/hash
-Small key speed test -    4-byte keys -    21.50 cycles/hash
-Small key speed test -    5-byte keys -    30.16 cycles/hash
-Small key speed test -    6-byte keys -    29.13 cycles/hash
-Small key speed test -    7-byte keys -    28.71 cycles/hash
-Small key speed test -    8-byte keys -    18.00 cycles/hash
-Small key speed test -    9-byte keys -    43.42 cycles/hash
-Small key speed test -   10-byte keys -    43.08 cycles/hash
-Small key speed test -   11-byte keys -    43.96 cycles/hash
-Small key speed test -   12-byte keys -    41.42 cycles/hash
-Small key speed test -   13-byte keys -    42.02 cycles/hash
-Small key speed test -   14-byte keys -    40.50 cycles/hash
-Small key speed test -   15-byte keys -    42.59 cycles/hash
-Small key speed test -   16-byte keys -    42.31 cycles/hash
-Small key speed test -   17-byte keys -    45.96 cycles/hash
-Small key speed test -   18-byte keys -    48.21 cycles/hash
-Small key speed test -   19-byte keys -    48.99 cycles/hash
-Small key speed test -   20-byte keys -    47.62 cycles/hash
-Small key speed test -   21-byte keys -    45.74 cycles/hash
-Small key speed test -   22-byte keys -    45.82 cycles/hash
-Small key speed test -   23-byte keys -    45.84 cycles/hash
-Small key speed test -   24-byte keys -    46.52 cycles/hash
-Small key speed test -   25-byte keys -    47.62 cycles/hash
-Small key speed test -   26-byte keys -    47.03 cycles/hash
-Small key speed test -   27-byte keys -    46.85 cycles/hash
-Small key speed test -   28-byte keys -    48.39 cycles/hash
-Small key speed test -   29-byte keys -    46.30 cycles/hash
-Small key speed test -   30-byte keys -    45.03 cycles/hash
-Small key speed test -   31-byte keys -    44.69 cycles/hash
-Average                                    39.636 cycles/hash
+Small key speed test -    1-byte keys -    20.09 cycles/hash
+Small key speed test -    2-byte keys -    18.54 cycles/hash
+Small key speed test -    3-byte keys -    17.54 cycles/hash
+Small key speed test -    4-byte keys -    17.98 cycles/hash
+Small key speed test -    5-byte keys -    27.52 cycles/hash
+Small key speed test -    6-byte keys -    31.47 cycles/hash
+Small key speed test -    7-byte keys -    32.31 cycles/hash
+Small key speed test -    8-byte keys -    23.51 cycles/hash
+Small key speed test -    9-byte keys -    41.91 cycles/hash
+Small key speed test -   10-byte keys -    39.38 cycles/hash
+Small key speed test -   11-byte keys -    37.98 cycles/hash
+Small key speed test -   12-byte keys -    37.90 cycles/hash
+Small key speed test -   13-byte keys -    37.73 cycles/hash
+Small key speed test -   14-byte keys -    36.88 cycles/hash
+Small key speed test -   15-byte keys -    36.79 cycles/hash
+Small key speed test -   16-byte keys -    37.49 cycles/hash
+Small key speed test -   17-byte keys -    45.24 cycles/hash
+Small key speed test -   18-byte keys -    45.78 cycles/hash
+Small key speed test -   19-byte keys -    42.31 cycles/hash
+Small key speed test -   20-byte keys -    39.75 cycles/hash
+Small key speed test -   21-byte keys -    38.00 cycles/hash
+Small key speed test -   22-byte keys -    38.00 cycles/hash
+Small key speed test -   23-byte keys -    39.56 cycles/hash
+Small key speed test -   24-byte keys -    40.72 cycles/hash
+Small key speed test -   25-byte keys -    40.89 cycles/hash
+Small key speed test -   26-byte keys -    40.89 cycles/hash
+Small key speed test -   27-byte keys -    40.89 cycles/hash
+Small key speed test -   28-byte keys -    40.78 cycles/hash
+Small key speed test -   29-byte keys -    40.43 cycles/hash
+Small key speed test -   30-byte keys -    41.63 cycles/hash
+Small key speed test -   31-byte keys -    42.66 cycles/hash
+Average                                    35.889 cycles/hash
 
 [[[ 'Hashmap' Speed Tests ]]]
 
 std::unordered_map
-Init std HashMapTest:     825.960 cycles/op (167303 inserts, 1% deletions)
-Running std HashMapTest:  490.340 cycles/op (43.4 stdv)
+Init std HashMapTest:     657.715 cycles/op (167303 inserts, 1% deletions)
+Running std HashMapTest:  434.203 cycles/op (39.1 stdv)
 
 greg7mdp/parallel-hashmap
-Init fast HashMapTest:    398.449 cycles/op (167303 inserts, 1% deletions)
-Running fast HashMapTest: 348.153 cycles/op (28.5 stdv)  ....... PASS
+Init fast HashMapTest:    356.548 cycles/op (167303 inserts, 1% deletions)
+Running fast HashMapTest: 333.218 cycles/op (25.5 stdv)  ....... PASS
 
 [[[ Avalanche Tests ]]]
 
@@ -71,11 +71,11 @@ Testing   40-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.594000%
 Testing   48-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.618667%
 Testing   56-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.714000%
 Testing   64-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.612000%
-Testing   72-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.642000%
-Testing   80-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.727333%
+Testing   72-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.654667%
+Testing   80-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.728000%
 Testing   96-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.688000%
-Testing  112-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.638667%
-Testing  128-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.682667%
+Testing  112-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.604667%
+Testing  128-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.660667%
 Testing  160-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.697333%
 Testing  512-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.780667%
 Testing 1024-bit keys ->  32-bit hashes, 300000 reps worst bias is 0.809333%
@@ -141,20 +141,20 @@ Testing collisions (low   8-bit) - Expected    8303377.0, actual 8303377 (1.00x)
 Testing distribution - Worst bias is the 20-bit window at bit 30 - 0.035%
 
 Keyset 'Sparse' - 72-bit keys with up to 5 bits set - 15082603 keys
-Testing collisions ( 32-bit) - Expected 26482.7, actual  26307 (0.99x) (-175)
+Testing collisions ( 32-bit) - Expected 26482.7, actual  26558 (1.00x) (76)
 Testing collisions (high 12-bit) - Expected   15078507.0, actual 15078507 (1.00x)
 Testing collisions (high  8-bit) - Expected   15082347.0, actual 15082347 (1.00x)
 Testing collisions (low  12-bit) - Expected   15078507.0, actual 15078507 (1.00x)
 Testing collisions (low   8-bit) - Expected   15082347.0, actual 15082347 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 23 - 0.021%
+Testing distribution - Worst bias is the 20-bit window at bit 21 - 0.027%
 
 Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
-Testing collisions ( 32-bit) - Expected 1401.3, actual   1417 (1.01x) (16)
+Testing collisions ( 32-bit) - Expected 1401.3, actual   1360 (0.97x)
 Testing collisions (high 12-bit) - Expected    3465401.0, actual 3465401 (1.00x)
 Testing collisions (high  8-bit) - Expected    3469241.0, actual 3469241 (1.00x)
 Testing collisions (low  12-bit) - Expected    3465401.0, actual 3465401 (1.00x)
 Testing collisions (low   8-bit) - Expected    3469241.0, actual 3469241 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 31 - 0.055%
+Testing distribution - Worst bias is the 19-bit window at bit  8 - 0.060%
 
 Keyset 'Sparse' - 160-bit keys with up to 4 bits set - 26977161 keys
 Testing collisions ( 32-bit) - Expected 84723.3, actual  84836 (1.00x) (113)
@@ -201,17 +201,17 @@ Testing distribution - Worst bias is the 18-bit window at bit 23 - 0.086%
 
 Combination Lowbits Tests:
 Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
-Testing collisions ( 32-bit) - Expected  668.7, actual    699 (1.05x) (31)
+Testing collisions ( 32-bit) - Expected  668.7, actual    698 (1.04x) (30)
 Testing collisions (high 12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
 Testing collisions (high  8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
 Testing collisions (low  12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
 Testing collisions (low   8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit  7 - 0.083%
+Testing distribution - Worst bias is the 18-bit window at bit  7 - 0.086%
 
 
 Combination Highbits Tests
 Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
-Testing collisions ( 32-bit) - Expected  668.7, actual    656 (0.98x) (-12)
+Testing collisions ( 32-bit) - Expected  668.7, actual    654 (0.98x)
 Testing collisions (high 12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
 Testing collisions (high  8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
 Testing collisions (low  12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
@@ -221,7 +221,7 @@ Testing distribution - Worst bias is the 18-bit window at bit 13 - 0.062%
 
 Combination Hi-Lo Tests:
 Keyset 'Combination' - up to 6 blocks from a set of 15 - 12204240 keys
-Testing collisions ( 32-bit) - Expected 17339.3, actual  17205 (0.99x) (-134)
+Testing collisions ( 32-bit) - Expected 17339.3, actual  17216 (0.99x) (-123)
 Testing collisions (high 12-bit) - Expected   12200144.0, actual 12200144 (1.00x)
 Testing collisions (high  8-bit) - Expected   12203984.0, actual 12203984 (1.00x)
 Testing collisions (low  12-bit) - Expected   12200144.0, actual 12200144 (1.00x)
@@ -352,79 +352,79 @@ Testing distribution - Worst bias is the 20-bit window at bit 15 - 0.035%
 [[[ Keyset 'Window' Tests ]]]
 
 Keyset 'Window' -  72-bit key,  20-bit window - 72 tests, 1048576 keys per test
-Window at   0 - Testing collisions ( 32-bit) - Expected  128.0, actual    122 (0.95x)
-Window at   1 - Testing collisions ( 32-bit) - Expected  128.0, actual    127 (0.99x)
-Window at   2 - Testing collisions ( 32-bit) - Expected  128.0, actual    127 (0.99x)
-Window at   3 - Testing collisions ( 32-bit) - Expected  128.0, actual    124 (0.97x)
-Window at   4 - Testing collisions ( 32-bit) - Expected  128.0, actual    129 (1.01x) (2)
-Window at   5 - Testing collisions ( 32-bit) - Expected  128.0, actual    125 (0.98x)
-Window at   6 - Testing collisions ( 32-bit) - Expected  128.0, actual    137 (1.07x) (10)
-Window at   7 - Testing collisions ( 32-bit) - Expected  128.0, actual    127 (0.99x)
-Window at   8 - Testing collisions ( 32-bit) - Expected  128.0, actual    132 (1.03x) (5)
-Window at   9 - Testing collisions ( 32-bit) - Expected  128.0, actual    107 (0.84x)
-Window at  10 - Testing collisions ( 32-bit) - Expected  128.0, actual    127 (0.99x)
-Window at  11 - Testing collisions ( 32-bit) - Expected  128.0, actual    149 (1.16x) (22)
-Window at  12 - Testing collisions ( 32-bit) - Expected  128.0, actual    114 (0.89x)
-Window at  13 - Testing collisions ( 32-bit) - Expected  128.0, actual    114 (0.89x)
-Window at  14 - Testing collisions ( 32-bit) - Expected  128.0, actual    119 (0.93x)
-Window at  15 - Testing collisions ( 32-bit) - Expected  128.0, actual    122 (0.95x)
-Window at  16 - Testing collisions ( 32-bit) - Expected  128.0, actual    120 (0.94x)
-Window at  17 - Testing collisions ( 32-bit) - Expected  128.0, actual    116 (0.91x)
-Window at  18 - Testing collisions ( 32-bit) - Expected  128.0, actual    125 (0.98x)
-Window at  19 - Testing collisions ( 32-bit) - Expected  128.0, actual    129 (1.01x) (2)
-Window at  20 - Testing collisions ( 32-bit) - Expected  128.0, actual    135 (1.05x) (8)
-Window at  21 - Testing collisions ( 32-bit) - Expected  128.0, actual    122 (0.95x)
-Window at  22 - Testing collisions ( 32-bit) - Expected  128.0, actual    123 (0.96x)
-Window at  23 - Testing collisions ( 32-bit) - Expected  128.0, actual    115 (0.90x)
-Window at  24 - Testing collisions ( 32-bit) - Expected  128.0, actual    131 (1.02x) (4)
-Window at  25 - Testing collisions ( 32-bit) - Expected  128.0, actual    122 (0.95x)
-Window at  26 - Testing collisions ( 32-bit) - Expected  128.0, actual    128 (1.00x) (1)
+Window at   0 - Testing collisions ( 32-bit) - Expected  128.0, actual    140 (1.09x) (13)
+Window at   1 - Testing collisions ( 32-bit) - Expected  128.0, actual    125 (0.98x)
+Window at   2 - Testing collisions ( 32-bit) - Expected  128.0, actual    136 (1.06x) (9)
+Window at   3 - Testing collisions ( 32-bit) - Expected  128.0, actual    131 (1.02x) (4)
+Window at   4 - Testing collisions ( 32-bit) - Expected  128.0, actual    124 (0.97x)
+Window at   5 - Testing collisions ( 32-bit) - Expected  128.0, actual    130 (1.02x) (3)
+Window at   6 - Testing collisions ( 32-bit) - Expected  128.0, actual    130 (1.02x) (3)
+Window at   7 - Testing collisions ( 32-bit) - Expected  128.0, actual    134 (1.05x) (7)
+Window at   8 - Testing collisions ( 32-bit) - Expected  128.0, actual    141 (1.10x) (14)
+Window at   9 - Testing collisions ( 32-bit) - Expected  128.0, actual    119 (0.93x)
+Window at  10 - Testing collisions ( 32-bit) - Expected  128.0, actual    139 (1.09x) (12)
+Window at  11 - Testing collisions ( 32-bit) - Expected  128.0, actual    142 (1.11x) (15)
+Window at  12 - Testing collisions ( 32-bit) - Expected  128.0, actual    131 (1.02x) (4)
+Window at  13 - Testing collisions ( 32-bit) - Expected  128.0, actual    113 (0.88x)
+Window at  14 - Testing collisions ( 32-bit) - Expected  128.0, actual    123 (0.96x)
+Window at  15 - Testing collisions ( 32-bit) - Expected  128.0, actual    132 (1.03x) (5)
+Window at  16 - Testing collisions ( 32-bit) - Expected  128.0, actual    110 (0.86x)
+Window at  17 - Testing collisions ( 32-bit) - Expected  128.0, actual    108 (0.84x)
+Window at  18 - Testing collisions ( 32-bit) - Expected  128.0, actual    129 (1.01x) (2)
+Window at  19 - Testing collisions ( 32-bit) - Expected  128.0, actual    132 (1.03x) (5)
+Window at  20 - Testing collisions ( 32-bit) - Expected  128.0, actual    127 (0.99x)
+Window at  21 - Testing collisions ( 32-bit) - Expected  128.0, actual    131 (1.02x) (4)
+Window at  22 - Testing collisions ( 32-bit) - Expected  128.0, actual    146 (1.14x) (19)
+Window at  23 - Testing collisions ( 32-bit) - Expected  128.0, actual    123 (0.96x)
+Window at  24 - Testing collisions ( 32-bit) - Expected  128.0, actual    129 (1.01x) (2)
+Window at  25 - Testing collisions ( 32-bit) - Expected  128.0, actual    145 (1.13x) (18)
+Window at  26 - Testing collisions ( 32-bit) - Expected  128.0, actual    148 (1.16x) (21)
 Window at  27 - Testing collisions ( 32-bit) - Expected  128.0, actual    141 (1.10x) (14)
-Window at  28 - Testing collisions ( 32-bit) - Expected  128.0, actual    129 (1.01x) (2)
-Window at  29 - Testing collisions ( 32-bit) - Expected  128.0, actual    142 (1.11x) (15)
-Window at  30 - Testing collisions ( 32-bit) - Expected  128.0, actual    109 (0.85x)
-Window at  31 - Testing collisions ( 32-bit) - Expected  128.0, actual    127 (0.99x)
-Window at  32 - Testing collisions ( 32-bit) - Expected  128.0, actual    139 (1.09x) (12)
-Window at  33 - Testing collisions ( 32-bit) - Expected  128.0, actual    123 (0.96x)
-Window at  34 - Testing collisions ( 32-bit) - Expected  128.0, actual    129 (1.01x) (2)
-Window at  35 - Testing collisions ( 32-bit) - Expected  128.0, actual    118 (0.92x)
-Window at  36 - Testing collisions ( 32-bit) - Expected  128.0, actual    108 (0.84x)
-Window at  37 - Testing collisions ( 32-bit) - Expected  128.0, actual    126 (0.98x) (-1)
-Window at  38 - Testing collisions ( 32-bit) - Expected  128.0, actual    105 (0.82x)
-Window at  39 - Testing collisions ( 32-bit) - Expected  128.0, actual    120 (0.94x)
-Window at  40 - Testing collisions ( 32-bit) - Expected  128.0, actual    131 (1.02x) (4)
-Window at  41 - Testing collisions ( 32-bit) - Expected  128.0, actual    134 (1.05x) (7)
-Window at  42 - Testing collisions ( 32-bit) - Expected  128.0, actual    115 (0.90x)
-Window at  43 - Testing collisions ( 32-bit) - Expected  128.0, actual    137 (1.07x) (10)
-Window at  44 - Testing collisions ( 32-bit) - Expected  128.0, actual    126 (0.98x) (-1)
-Window at  45 - Testing collisions ( 32-bit) - Expected  128.0, actual    116 (0.91x)
-Window at  46 - Testing collisions ( 32-bit) - Expected  128.0, actual    144 (1.13x) (17)
-Window at  47 - Testing collisions ( 32-bit) - Expected  128.0, actual    147 (1.15x) (20)
-Window at  48 - Testing collisions ( 32-bit) - Expected  128.0, actual    150 (1.17x) (23)
-Window at  49 - Testing collisions ( 32-bit) - Expected  128.0, actual    137 (1.07x) (10)
-Window at  50 - Testing collisions ( 32-bit) - Expected  128.0, actual    136 (1.06x) (9)
-Window at  51 - Testing collisions ( 32-bit) - Expected  128.0, actual    128 (1.00x) (1)
-Window at  52 - Testing collisions ( 32-bit) - Expected  128.0, actual    135 (1.05x) (8)
-Window at  53 - Testing collisions ( 32-bit) - Expected  128.0, actual    130 (1.02x) (3)
-Window at  54 - Testing collisions ( 32-bit) - Expected  128.0, actual     98 (0.77x)
-Window at  55 - Testing collisions ( 32-bit) - Expected  128.0, actual    110 (0.86x)
-Window at  56 - Testing collisions ( 32-bit) - Expected  128.0, actual    114 (0.89x)
-Window at  57 - Testing collisions ( 32-bit) - Expected  128.0, actual    113 (0.88x)
-Window at  58 - Testing collisions ( 32-bit) - Expected  128.0, actual    126 (0.98x) (-1)
-Window at  59 - Testing collisions ( 32-bit) - Expected  128.0, actual    132 (1.03x) (5)
-Window at  60 - Testing collisions ( 32-bit) - Expected  128.0, actual    123 (0.96x)
-Window at  61 - Testing collisions ( 32-bit) - Expected  128.0, actual    129 (1.01x) (2)
-Window at  62 - Testing collisions ( 32-bit) - Expected  128.0, actual    137 (1.07x) (10)
-Window at  63 - Testing collisions ( 32-bit) - Expected  128.0, actual    119 (0.93x)
-Window at  64 - Testing collisions ( 32-bit) - Expected  128.0, actual    139 (1.09x) (12)
-Window at  65 - Testing collisions ( 32-bit) - Expected  128.0, actual    122 (0.95x)
-Window at  66 - Testing collisions ( 32-bit) - Expected  128.0, actual    154 (1.20x) (27)
-Window at  67 - Testing collisions ( 32-bit) - Expected  128.0, actual    136 (1.06x) (9)
-Window at  68 - Testing collisions ( 32-bit) - Expected  128.0, actual    130 (1.02x) (3)
-Window at  69 - Testing collisions ( 32-bit) - Expected  128.0, actual    121 (0.95x)
-Window at  70 - Testing collisions ( 32-bit) - Expected  128.0, actual    121 (0.95x)
-Window at  71 - Testing collisions ( 32-bit) - Expected  128.0, actual    130 (1.02x) (3)
-Window at  72 - Testing collisions ( 32-bit) - Expected  128.0, actual    122 (0.95x)
+Window at  28 - Testing collisions ( 32-bit) - Expected  128.0, actual    138 (1.08x) (11)
+Window at  29 - Testing collisions ( 32-bit) - Expected  128.0, actual    140 (1.09x) (13)
+Window at  30 - Testing collisions ( 32-bit) - Expected  128.0, actual    113 (0.88x)
+Window at  31 - Testing collisions ( 32-bit) - Expected  128.0, actual    133 (1.04x) (6)
+Window at  32 - Testing collisions ( 32-bit) - Expected  128.0, actual    124 (0.97x)
+Window at  33 - Testing collisions ( 32-bit) - Expected  128.0, actual    138 (1.08x) (11)
+Window at  34 - Testing collisions ( 32-bit) - Expected  128.0, actual    121 (0.95x)
+Window at  35 - Testing collisions ( 32-bit) - Expected  128.0, actual    127 (0.99x)
+Window at  36 - Testing collisions ( 32-bit) - Expected  128.0, actual    114 (0.89x)
+Window at  37 - Testing collisions ( 32-bit) - Expected  128.0, actual    130 (1.02x) (3)
+Window at  38 - Testing collisions ( 32-bit) - Expected  128.0, actual    124 (0.97x)
+Window at  39 - Testing collisions ( 32-bit) - Expected  128.0, actual    112 (0.88x)
+Window at  40 - Testing collisions ( 32-bit) - Expected  128.0, actual    141 (1.10x) (14)
+Window at  41 - Testing collisions ( 32-bit) - Expected  128.0, actual    128 (1.00x) (1)
+Window at  42 - Testing collisions ( 32-bit) - Expected  128.0, actual    125 (0.98x)
+Window at  43 - Testing collisions ( 32-bit) - Expected  128.0, actual    109 (0.85x)
+Window at  44 - Testing collisions ( 32-bit) - Expected  128.0, actual    122 (0.95x)
+Window at  45 - Testing collisions ( 32-bit) - Expected  128.0, actual    133 (1.04x) (6)
+Window at  46 - Testing collisions ( 32-bit) - Expected  128.0, actual    113 (0.88x)
+Window at  47 - Testing collisions ( 32-bit) - Expected  128.0, actual    145 (1.13x) (18)
+Window at  48 - Testing collisions ( 32-bit) - Expected  128.0, actual    143 (1.12x) (16)
+Window at  49 - Testing collisions ( 32-bit) - Expected  128.0, actual    123 (0.96x)
+Window at  50 - Testing collisions ( 32-bit) - Expected  128.0, actual    127 (0.99x)
+Window at  51 - Testing collisions ( 32-bit) - Expected  128.0, actual    121 (0.95x)
+Window at  52 - Testing collisions ( 32-bit) - Expected  128.0, actual    137 (1.07x) (10)
+Window at  53 - Testing collisions ( 32-bit) - Expected  128.0, actual    129 (1.01x) (2)
+Window at  54 - Testing collisions ( 32-bit) - Expected  128.0, actual    153 (1.20x) (26)
+Window at  55 - Testing collisions ( 32-bit) - Expected  128.0, actual    152 (1.19x) (25)
+Window at  56 - Testing collisions ( 32-bit) - Expected  128.0, actual    144 (1.13x) (17)
+Window at  57 - Testing collisions ( 32-bit) - Expected  128.0, actual    140 (1.09x) (13)
+Window at  58 - Testing collisions ( 32-bit) - Expected  128.0, actual    115 (0.90x)
+Window at  59 - Testing collisions ( 32-bit) - Expected  128.0, actual    129 (1.01x) (2)
+Window at  60 - Testing collisions ( 32-bit) - Expected  128.0, actual    130 (1.02x) (3)
+Window at  61 - Testing collisions ( 32-bit) - Expected  128.0, actual    121 (0.95x)
+Window at  62 - Testing collisions ( 32-bit) - Expected  128.0, actual    118 (0.92x)
+Window at  63 - Testing collisions ( 32-bit) - Expected  128.0, actual    130 (1.02x) (3)
+Window at  64 - Testing collisions ( 32-bit) - Expected  128.0, actual    114 (0.89x)
+Window at  65 - Testing collisions ( 32-bit) - Expected  128.0, actual    132 (1.03x) (5)
+Window at  66 - Testing collisions ( 32-bit) - Expected  128.0, actual    145 (1.13x) (18)
+Window at  67 - Testing collisions ( 32-bit) - Expected  128.0, actual    125 (0.98x)
+Window at  68 - Testing collisions ( 32-bit) - Expected  128.0, actual    115 (0.90x)
+Window at  69 - Testing collisions ( 32-bit) - Expected  128.0, actual    144 (1.13x) (17)
+Window at  70 - Testing collisions ( 32-bit) - Expected  128.0, actual    140 (1.09x) (13)
+Window at  71 - Testing collisions ( 32-bit) - Expected  128.0, actual    141 (1.10x) (14)
+Window at  72 - Testing collisions ( 32-bit) - Expected  128.0, actual    140 (1.09x) (13)
 
 [[[ Keyset 'Cyclic' Tests ]]]
 
@@ -496,31 +496,31 @@ Testing collisions (low   8-bit) - Expected    5470769.0, actual 5470769 (1.00x)
 Testing distribution - Worst bias is the 19-bit window at bit  5 - 0.034%
 
 Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
-Testing collisions ( 32-bit) - Expected 40347.8, actual  40486 (1.00x) (139)
+Testing collisions ( 32-bit) - Expected 40347.8, actual  40144 (0.99x) (-203)
 Testing collisions (high 12-bit) - Expected   18612689.0, actual 18612689 (1.00x)
 Testing collisions (high  8-bit) - Expected   18616529.0, actual 18616529 (1.00x)
 Testing collisions (low  12-bit) - Expected   18612689.0, actual 18612689 (1.00x)
 Testing collisions (low   8-bit) - Expected   18616529.0, actual 18616529 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 16 - 0.014%
+Testing distribution - Worst bias is the 20-bit window at bit 28 - 0.013%
 
 Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
-Testing collisions ( 32-bit) - Expected 227963.2, actual 227869 (1.00x) (-94)
+Testing collisions ( 32-bit) - Expected 227963.2, actual 226815 (0.99x) (-1148)
 Testing collisions (high 12-bit) - Expected   44247329.0, actual 44247329 (1.00x)
 Testing collisions (high  8-bit) - Expected   44251169.0, actual 44251169 (1.00x)
 Testing collisions (low  12-bit) - Expected   44247329.0, actual 44247329 (1.00x)
 Testing collisions (low   8-bit) - Expected   44251169.0, actual 44251169 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 30 - 0.007%
+Testing distribution - Worst bias is the 20-bit window at bit  3 - 0.008%
 
 Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
-Testing collisions ( 32-bit) - Expected 871784.7, actual 866398 (0.99x) (-5386)
+Testing collisions ( 32-bit) - Expected 871784.7, actual 865870 (0.99x) (-5914)
 Testing collisions (high 12-bit) - Expected   86532449.0, actual 86532449 (1.00x)
 Testing collisions (high  8-bit) - Expected   86536289.0, actual 86536289 (1.00x)
 Testing collisions (low  12-bit) - Expected   86532449.0, actual 86532449 (1.00x)
 Testing collisions (low   8-bit) - Expected   86536289.0, actual 86536289 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 20 - 0.003%
+Testing distribution - Worst bias is the 20-bit window at bit  5 - 0.003%
 
 Keyset 'TwoBytes' - up-to-24-byte keys, 149633745 total keys
-Testing collisions ( 32-bit) - Expected 2606569.0, actual 2578689 (0.99x) (-27880)
+Testing collisions ( 32-bit) - Expected 2606569.0, actual 2579275 (0.99x) (-27294)
 Testing collisions (high 12-bit) - Expected  149629649.0, actual 149629649 (1.00x)
 Testing collisions (high  8-bit) - Expected  149633489.0, actual 149633489 (1.00x)
 Testing collisions (low  12-bit) - Expected  149629649.0, actual 149629649 (1.00x)
@@ -531,54 +531,54 @@ Testing distribution - Worst bias is the 20-bit window at bit 20 - 0.002%
 [[[ Keyset 'Text' Tests ]]]
 
 Keyset 'Text' - keys of form "FooXXXXBar" - 14776336 keys
-Testing collisions ( 32-bit) - Expected 25418.1, actual  25423 (1.00x) (5)
+Testing collisions ( 32-bit) - Expected 25418.1, actual  25360 (1.00x) (-58)
 Testing collisions (high 12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (high  8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
 Testing collisions (low  12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (low   8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 11 - 0.027%
+Testing distribution - Worst bias is the 20-bit window at bit 28 - 0.012%
 
 Keyset 'Text' - keys of form "FooBarXXXX" - 14776336 keys
-Testing collisions ( 32-bit) - Expected 25418.1, actual  25554 (1.01x) (136)
+Testing collisions ( 32-bit) - Expected 25418.1, actual  25563 (1.01x) (145)
 Testing collisions (high 12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (high  8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
 Testing collisions (low  12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (low   8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 13 - 0.015%
+Testing distribution - Worst bias is the 20-bit window at bit  4 - 0.017%
 
 Keyset 'Text' - keys of form "XXXXFooBar" - 14776336 keys
-Testing collisions ( 32-bit) - Expected 25418.1, actual  25495 (1.00x) (77)
+Testing collisions ( 32-bit) - Expected 25418.1, actual  25376 (1.00x) (-42)
 Testing collisions (high 12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (high  8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
 Testing collisions (low  12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (low   8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 26 - 0.027%
+Testing distribution - Worst bias is the 20-bit window at bit  2 - 0.032%
 
 Keyset 'Words' - 4000000 random keys of len 6-16 from alnum charset
-Testing collisions ( 32-bit) - Expected 1862.6, actual   1924 (1.03x) (62)
+Testing collisions ( 32-bit) - Expected 1862.6, actual   1861 (1.00x) (-1)
 Testing collisions (high 12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (high  8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
 Testing collisions (low  12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (low   8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 23 - 0.047%
+Testing distribution - Worst bias is the 19-bit window at bit 13 - 0.034%
 
 Keyset 'Words' - 4000000 random keys of len 6-16 from password charset
-Testing collisions ( 32-bit) - Expected 1862.6, actual   1939 (1.04x) (77)
+Testing collisions ( 32-bit) - Expected 1862.6, actual   1872 (1.01x) (10)
 Testing collisions (high 12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (high  8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
 Testing collisions (low  12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (low   8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit  1 - 0.025%
+Testing distribution - Worst bias is the 19-bit window at bit 21 - 0.061%
 
 Keyset 'Words' - 167303 dict words
-Testing collisions ( 32-bit) - Expected    3.3, actual      2 (0.61x)
-Testing collisions (high 21-29 bits) - Worst is 21 bits: 6528/6673 (0.98x)
+Testing collisions ( 32-bit) - Expected    3.3, actual      4 (1.23x) (1)
+Testing collisions (high 21-29 bits) - Worst is 22 bits: 3387/3336 (1.02x)
 Testing collisions (high 12-bit) - Expected     163207.0, actual 163207 (1.00x)
 Testing collisions (high  8-bit) - Expected     167047.0, actual 167047 (1.00x)
-Testing collisions (low  21-29 bits) - Worst is 22 bits: 3346/3336 (1.00x)
+Testing collisions (low  21-29 bits) - Worst is 27 bits: 112/104 (1.07x)
 Testing collisions (low  12-bit) - Expected     163207.0, actual 163207 (1.00x)
 Testing collisions (low   8-bit) - Expected     167047.0, actual 167047 (1.00x)
-Testing distribution - Worst bias is the 15-bit window at bit  0 - 0.420%
+Testing distribution - Worst bias is the 15-bit window at bit 30 - 0.193%
 
 
 [[[ Keyset 'Zeroes' Tests ]]]
@@ -591,7 +591,7 @@ Testing collisions (high  8-bit) - Expected     204544.0, actual 204544 (1.00x)
 Testing collisions (low  21-29 bits) - Worst is 29 bits: 41/39 (1.05x)
 Testing collisions (low  12-bit) - Expected     200704.0, actual 200704 (1.00x)
 Testing collisions (low   8-bit) - Expected     204544.0, actual 204544 (1.00x)
-Testing distribution - Worst bias is the 15-bit window at bit 28 - 0.250%
+Testing distribution - Worst bias is the 15-bit window at bit 28 - 0.248%
 
 
 [[[ Keyset 'Seed' Tests ]]]
@@ -623,7 +623,7 @@ Testing 8303632 up-to-5-bit differentials in 64-bit keys -> 32 bit hashes.
 
 Testing 11017632 up-to-4-bit differentials in 128-bit keys -> 32 bit hashes.
 1000 reps, 11017632000 total tests, expecting 2.57 random collisions..........
-3 total collisions, of which 3 single collisions were ignored
+2 total collisions, of which 2 single collisions were ignored
 
 Testing 2796416 up-to-3-bit differentials in 256-bit keys -> 32 bit hashes.
 1000 reps, 2796416000 total tests, expecting 0.65 random collisions..........
@@ -1105,5 +1105,5 @@ The PRNG test is designed for hashes >= 64-bit
 
 
 Input vcode 0x00000001, Output vcode 0x00000001, Result vcode 0x00000001
-Verification value is 0x00000001 - Testing took 1321.243183 seconds
+Verification value is 0x00000001 - Testing took 1352.127726 seconds
 -------------------------------------------------------------------------------

--- a/smhasher/umash64.log
+++ b/smhasher/umash64.log
@@ -3,65 +3,65 @@
 
 [[[ Sanity Tests ]]]
 
-Verification value 0x28D2626F ....... PASS
+Verification value 0xB0B11994 ....... PASS
 Running sanity check 1     .......... PASS
 Running AppendedZeroesTest .......... PASS
 
 [[[ Speed Tests ]]]
 
 Bulk speed test - 262144-byte keys
-Alignment  7 -  9.325 bytes/cycle - 26679.10 MiB/sec @ 3 ghz
-Alignment  6 -  9.137 bytes/cycle - 26140.13 MiB/sec @ 3 ghz
-Alignment  5 -  9.575 bytes/cycle - 27395.24 MiB/sec @ 3 ghz
-Alignment  4 -  9.319 bytes/cycle - 26660.54 MiB/sec @ 3 ghz
-Alignment  3 -  9.139 bytes/cycle - 26147.21 MiB/sec @ 3 ghz
-Alignment  2 -  7.394 bytes/cycle - 21154.58 MiB/sec @ 3 ghz
-Alignment  1 -  5.976 bytes/cycle - 17096.09 MiB/sec @ 3 ghz
-Alignment  0 -  7.325 bytes/cycle - 20957.40 MiB/sec @ 3 ghz
-Average      -  8.399 bytes/cycle - 24028.79 MiB/sec @ 3 ghz
+Alignment  7 -  6.144 bytes/cycle - 17578.45 MiB/sec @ 3 ghz
+Alignment  6 -  6.292 bytes/cycle - 18000.73 MiB/sec @ 3 ghz
+Alignment  5 -  7.139 bytes/cycle - 20425.20 MiB/sec @ 3 ghz
+Alignment  4 -  9.274 bytes/cycle - 26533.27 MiB/sec @ 3 ghz
+Alignment  3 -  9.419 bytes/cycle - 26946.75 MiB/sec @ 3 ghz
+Alignment  2 -  6.823 bytes/cycle - 19520.81 MiB/sec @ 3 ghz
+Alignment  1 -  6.975 bytes/cycle - 19954.93 MiB/sec @ 3 ghz
+Alignment  0 -  9.747 bytes/cycle - 27887.47 MiB/sec @ 3 ghz
+Average      -  7.727 bytes/cycle - 22105.95 MiB/sec @ 3 ghz
 
-Small key speed test -    1-byte keys -    20.09 cycles/hash
-Small key speed test -    2-byte keys -    22.05 cycles/hash
-Small key speed test -    3-byte keys -    22.67 cycles/hash
-Small key speed test -    4-byte keys -    18.84 cycles/hash
-Small key speed test -    5-byte keys -    26.42 cycles/hash
-Small key speed test -    6-byte keys -    26.64 cycles/hash
-Small key speed test -    7-byte keys -    26.04 cycles/hash
-Small key speed test -    8-byte keys -    21.17 cycles/hash
-Small key speed test -    9-byte keys -    40.18 cycles/hash
-Small key speed test -   10-byte keys -    40.54 cycles/hash
-Small key speed test -   11-byte keys -    40.32 cycles/hash
-Small key speed test -   12-byte keys -    39.93 cycles/hash
-Small key speed test -   13-byte keys -    38.16 cycles/hash
-Small key speed test -   14-byte keys -    39.12 cycles/hash
-Small key speed test -   15-byte keys -    37.59 cycles/hash
-Small key speed test -   16-byte keys -    38.67 cycles/hash
-Small key speed test -   17-byte keys -    43.11 cycles/hash
-Small key speed test -   18-byte keys -    44.39 cycles/hash
-Small key speed test -   19-byte keys -    44.61 cycles/hash
-Small key speed test -   20-byte keys -    42.70 cycles/hash
-Small key speed test -   21-byte keys -    40.00 cycles/hash
-Small key speed test -   22-byte keys -    39.74 cycles/hash
-Small key speed test -   23-byte keys -    43.61 cycles/hash
-Small key speed test -   24-byte keys -    42.48 cycles/hash
-Small key speed test -   25-byte keys -    42.35 cycles/hash
-Small key speed test -   26-byte keys -    42.84 cycles/hash
-Small key speed test -   27-byte keys -    42.94 cycles/hash
-Small key speed test -   28-byte keys -    42.63 cycles/hash
-Small key speed test -   29-byte keys -    42.54 cycles/hash
-Small key speed test -   30-byte keys -    41.25 cycles/hash
-Small key speed test -   31-byte keys -    41.76 cycles/hash
-Average                                    36.625 cycles/hash
+Small key speed test -    1-byte keys -    30.61 cycles/hash
+Small key speed test -    2-byte keys -    29.31 cycles/hash
+Small key speed test -    3-byte keys -    25.76 cycles/hash
+Small key speed test -    4-byte keys -    20.54 cycles/hash
+Small key speed test -    5-byte keys -    24.43 cycles/hash
+Small key speed test -    6-byte keys -    24.78 cycles/hash
+Small key speed test -    7-byte keys -    24.65 cycles/hash
+Small key speed test -    8-byte keys -    15.00 cycles/hash
+Small key speed test -    9-byte keys -    33.39 cycles/hash
+Small key speed test -   10-byte keys -    32.72 cycles/hash
+Small key speed test -   11-byte keys -    32.60 cycles/hash
+Small key speed test -   12-byte keys -    32.59 cycles/hash
+Small key speed test -   13-byte keys -    32.88 cycles/hash
+Small key speed test -   14-byte keys -    32.16 cycles/hash
+Small key speed test -   15-byte keys -    31.81 cycles/hash
+Small key speed test -   16-byte keys -    32.38 cycles/hash
+Small key speed test -   17-byte keys -    41.73 cycles/hash
+Small key speed test -   18-byte keys -    41.44 cycles/hash
+Small key speed test -   19-byte keys -    41.46 cycles/hash
+Small key speed test -   20-byte keys -    41.00 cycles/hash
+Small key speed test -   21-byte keys -    42.32 cycles/hash
+Small key speed test -   22-byte keys -    41.82 cycles/hash
+Small key speed test -   23-byte keys -    41.75 cycles/hash
+Small key speed test -   24-byte keys -    42.18 cycles/hash
+Small key speed test -   25-byte keys -    40.46 cycles/hash
+Small key speed test -   26-byte keys -    39.36 cycles/hash
+Small key speed test -   27-byte keys -    38.72 cycles/hash
+Small key speed test -   28-byte keys -    40.08 cycles/hash
+Small key speed test -   29-byte keys -    40.80 cycles/hash
+Small key speed test -   30-byte keys -    39.99 cycles/hash
+Small key speed test -   31-byte keys -    40.91 cycles/hash
+Average                                    34.505 cycles/hash
 
 [[[ 'Hashmap' Speed Tests ]]]
 
 std::unordered_map
-Init std HashMapTest:     769.413 cycles/op (167303 inserts, 1% deletions)
-Running std HashMapTest:  411.360 cycles/op (43.7 stdv)
+Init std HashMapTest:     688.565 cycles/op (167303 inserts, 1% deletions)
+Running std HashMapTest:  402.474 cycles/op (38.1 stdv)
 
 greg7mdp/parallel-hashmap
-Init fast HashMapTest:    504.751 cycles/op (167303 inserts, 1% deletions)
-Running fast HashMapTest: 289.234 cycles/op (28.5 stdv)  ....... PASS
+Init fast HashMapTest:    339.651 cycles/op (167303 inserts, 1% deletions)
+Running fast HashMapTest: 308.669 cycles/op (34.2 stdv)  ....... PASS
 
 [[[ Avalanche Tests ]]]
 
@@ -71,11 +71,11 @@ Testing   40-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.646000%
 Testing   48-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.618667%
 Testing   56-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.714000%
 Testing   64-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.688667%
-Testing   72-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.642000%
-Testing   80-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.757333%
+Testing   72-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.654667%
+Testing   80-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.728000%
 Testing   96-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.688000%
-Testing  112-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.783333%
-Testing  128-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.688000%
+Testing  112-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.684667%
+Testing  128-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.660667%
 Testing  160-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.697333%
 Testing  512-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.780667%
 Testing 1024-bit keys ->  64-bit hashes, 300000 reps worst bias is 0.809333%
@@ -168,27 +168,27 @@ Testing distribution - Worst bias is the 20-bit window at bit 50 - 0.040%
 
 Keyset 'Sparse' - 72-bit keys with up to 5 bits set - 15082603 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      26482.7, actual  26307 (0.99x) (-175)
-Testing collisions (high 27-42 bits) - Worst is 34 bits: 6647/6620 (1.00x)
+Testing collisions (high 32-bit) - Expected      26482.7, actual  26558 (1.00x) (76)
+Testing collisions (high 27-42 bits) - Worst is 41 bits: 58/51 (1.12x)
 Testing collisions (high 12-bit) - Expected   15078507.0, actual 15078507 (1.00x)
 Testing collisions (high  8-bit) - Expected   15082347.0, actual 15082347 (1.00x)
-Testing collisions (low  32-bit) - Expected      26482.7, actual  26601 (1.00x) (119)
-Testing collisions (low  27-42 bits) - Worst is 41 bits: 63/51 (1.22x)
+Testing collisions (low  32-bit) - Expected      26482.7, actual  26163 (0.99x) (-319)
+Testing collisions (low  27-42 bits) - Worst is 42 bits: 28/25 (1.08x)
 Testing collisions (low  12-bit) - Expected   15078507.0, actual 15078507 (1.00x)
 Testing collisions (low   8-bit) - Expected   15082347.0, actual 15082347 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit  5 - 0.024%
+Testing distribution - Worst bias is the 20-bit window at bit 27 - 0.027%
 
 Keyset 'Sparse' - 96-bit keys with up to 4 bits set - 3469497 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1401.3, actual   1417 (1.01x) (16)
-Testing collisions (high 25-38 bits) - Worst is 37 bits: 46/43 (1.05x)
+Testing collisions (high 32-bit) - Expected       1401.3, actual   1360 (0.97x)
+Testing collisions (high 25-38 bits) - Worst is 38 bits: 35/21 (1.60x)
 Testing collisions (high 12-bit) - Expected    3465401.0, actual 3465401 (1.00x)
 Testing collisions (high  8-bit) - Expected    3469241.0, actual 3469241 (1.00x)
-Testing collisions (low  32-bit) - Expected       1401.3, actual   1471 (1.05x) (70)
-Testing collisions (low  25-38 bits) - Worst is 37 bits: 48/43 (1.10x)
+Testing collisions (low  32-bit) - Expected       1401.3, actual   1346 (0.96x)
+Testing collisions (low  25-38 bits) - Worst is 29 bits: 11155/11210 (1.00x)
 Testing collisions (low  12-bit) - Expected    3465401.0, actual 3465401 (1.00x)
 Testing collisions (low   8-bit) - Expected    3469241.0, actual 3469241 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 37 - 0.049%
+Testing distribution - Worst bias is the 19-bit window at bit 40 - 0.060%
 
 Keyset 'Sparse' - 160-bit keys with up to 4 bits set - 26977161 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
@@ -256,26 +256,26 @@ Testing distribution - Worst bias is the 18-bit window at bit 30 - 0.065%
 Combination Lowbits Tests:
 Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        668.7, actual    699 (1.05x) (31)
-Testing collisions (high 25-37 bits) - Worst is 34 bits: 196/167 (1.17x)
+Testing collisions (high 32-bit) - Expected        668.7, actual    698 (1.04x) (30)
+Testing collisions (high 25-37 bits) - Worst is 34 bits: 194/167 (1.16x)
 Testing collisions (high 12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
 Testing collisions (high  8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
-Testing collisions (low  32-bit) - Expected        668.7, actual    717 (1.07x) (49)
-Testing collisions (low  25-37 bits) - Worst is 32 bits: 717/668 (1.07x)
+Testing collisions (low  32-bit) - Expected        668.7, actual    720 (1.08x) (52)
+Testing collisions (low  25-37 bits) - Worst is 32 bits: 720/668 (1.08x)
 Testing collisions (low  12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
 Testing collisions (low   8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
-Testing distribution - Worst bias is the 18-bit window at bit 39 - 0.083%
+Testing distribution - Worst bias is the 18-bit window at bit 39 - 0.086%
 
 
 Combination Highbits Tests
 Keyset 'Combination' - up to 7 blocks from a set of 8 - 2396744 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected        668.7, actual    656 (0.98x) (-12)
+Testing collisions (high 32-bit) - Expected        668.7, actual    654 (0.98x)
 Testing collisions (high 25-37 bits) - Worst is 37 bits: 27/20 (1.29x)
 Testing collisions (high 12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
 Testing collisions (high  8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
-Testing collisions (low  32-bit) - Expected        668.7, actual    675 (1.01x) (7)
-Testing collisions (low  25-37 bits) - Worst is 36 bits: 45/41 (1.08x)
+Testing collisions (low  32-bit) - Expected        668.7, actual    677 (1.01x) (9)
+Testing collisions (low  25-37 bits) - Worst is 36 bits: 44/41 (1.05x)
 Testing collisions (low  12-bit) - Expected    2392648.0, actual 2392648 (1.00x)
 Testing collisions (low   8-bit) - Expected    2396488.0, actual 2396488 (1.00x)
 Testing distribution - Worst bias is the 18-bit window at bit 45 - 0.062%
@@ -284,15 +284,15 @@ Testing distribution - Worst bias is the 18-bit window at bit 45 - 0.062%
 Combination Hi-Lo Tests:
 Keyset 'Combination' - up to 6 blocks from a set of 15 - 12204240 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      17339.3, actual  17205 (0.99x) (-134)
+Testing collisions (high 32-bit) - Expected      17339.3, actual  17216 (0.99x) (-123)
 Testing collisions (high 27-41 bits) - Worst is 38 bits: 286/270 (1.06x)
 Testing collisions (high 12-bit) - Expected   12200144.0, actual 12200144 (1.00x)
 Testing collisions (high  8-bit) - Expected   12203984.0, actual 12203984 (1.00x)
-Testing collisions (low  32-bit) - Expected      17339.3, actual  17353 (1.00x) (14)
-Testing collisions (low  27-41 bits) - Worst is 34 bits: 4411/4334 (1.02x)
+Testing collisions (low  32-bit) - Expected      17339.3, actual  17354 (1.00x) (15)
+Testing collisions (low  27-41 bits) - Worst is 34 bits: 4416/4334 (1.02x)
 Testing collisions (low  12-bit) - Expected   12200144.0, actual 12200144 (1.00x)
 Testing collisions (low   8-bit) - Expected   12203984.0, actual 12203984 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 16 - 0.030%
+Testing distribution - Worst bias is the 20-bit window at bit 16 - 0.029%
 
 
 Combination 0x8000000 Tests:
@@ -303,7 +303,7 @@ Testing collisions (high 26-40 bits) - Worst is 37 bits: 259/255 (1.01x)
 Testing collisions (high 12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
 Testing collisions (high  8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
 Testing collisions (low  32-bit) - Expected       8192.0, actual   8066 (0.98x) (-125)
-Testing collisions (low  26-40 bits) - Worst is 29 bits: 65379/65535 (1.00x)
+Testing collisions (low  26-40 bits) - Worst is 29 bits: 65378/65535 (1.00x)
 Testing collisions (low  12-bit) - Expected    8384510.0, actual 8384510 (1.00x)
 Testing collisions (low   8-bit) - Expected    8388350.0, actual 8388350 (1.00x)
 Testing distribution - Worst bias is the 20-bit window at bit 55 - 0.040%
@@ -603,114 +603,114 @@ Testing distribution - Worst bias is the 20-bit window at bit  2 - 0.075%
 
 Keyset 'TwoBytes' - up-to-12-byte keys, 18616785 total keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      40347.8, actual  40486 (1.00x) (139)
-Testing collisions (high 27-42 bits) - Worst is 37 bits: 1321/1260 (1.05x)
+Testing collisions (high 32-bit) - Expected      40347.8, actual  40144 (0.99x) (-203)
+Testing collisions (high 27-42 bits) - Worst is 41 bits: 83/78 (1.05x)
 Testing collisions (high 12-bit) - Expected   18612689.0, actual 18612689 (1.00x)
 Testing collisions (high  8-bit) - Expected   18616529.0, actual 18616529 (1.00x)
-Testing collisions (low  32-bit) - Expected      40347.8, actual  40162 (1.00x) (-185)
-Testing collisions (low  27-42 bits) - Worst is 42 bits: 50/39 (1.27x)
+Testing collisions (low  32-bit) - Expected      40347.8, actual  40169 (1.00x) (-178)
+Testing collisions (low  27-42 bits) - Worst is 41 bits: 94/78 (1.19x)
 Testing collisions (low  12-bit) - Expected   18612689.0, actual 18612689 (1.00x)
 Testing collisions (low   8-bit) - Expected   18616529.0, actual 18616529 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit  0 - 0.025%
+Testing distribution - Worst bias is the 20-bit window at bit  7 - 0.018%
 
 Keyset 'TwoBytes' - up-to-16-byte keys, 44251425 total keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected     227963.2, actual 227869 (1.00x) (-94)
-Testing collisions (high 29-45 bits) - Worst is 44 bits: 61/55 (1.10x)
+Testing collisions (high 32-bit) - Expected     227963.2, actual 226815 (0.99x) (-1148)
+Testing collisions (high 29-45 bits) - Worst is 35 bits: 28779/28495 (1.01x)
 Testing collisions (high 12-bit) - Expected   44247329.0, actual 44247329 (1.00x)
 Testing collisions (high  8-bit) - Expected   44251169.0, actual 44251169 (1.00x)
-Testing collisions (low  32-bit) - Expected     227963.2, actual 226937 (1.00x) (-1026)
-Testing collisions (low  29-45 bits) - Worst is 41 bits: 511/445 (1.15x)
+Testing collisions (low  32-bit) - Expected     227963.2, actual 227637 (1.00x) (-326)
+Testing collisions (low  29-45 bits) - Worst is 41 bits: 472/445 (1.06x)
 Testing collisions (low  12-bit) - Expected   44247329.0, actual 44247329 (1.00x)
 Testing collisions (low   8-bit) - Expected   44251169.0, actual 44251169 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 61 - 0.006%
+Testing distribution - Worst bias is the 20-bit window at bit 35 - 0.008%
 
 Keyset 'TwoBytes' - up-to-20-byte keys, 86536545 total keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected     871784.7, actual 866398 (0.99x) (-5386)
-Testing collisions (high 30-47 bits) - Worst is 40 bits: 3453/3405 (1.01x)
+Testing collisions (high 32-bit) - Expected     871784.7, actual 865870 (0.99x) (-5914)
+Testing collisions (high 30-47 bits) - Worst is 38 bits: 13747/13621 (1.01x)
 Testing collisions (high 12-bit) - Expected   86532449.0, actual 86532449 (1.00x)
 Testing collisions (high  8-bit) - Expected   86536289.0, actual 86536289 (1.00x)
-Testing collisions (low  32-bit) - Expected     871784.7, actual 866685 (0.99x) (-5099)
-Testing collisions (low  30-47 bits) - Worst is 42 bits: 898/851 (1.05x)
+Testing collisions (low  32-bit) - Expected     871784.7, actual 867201 (0.99x) (-4583)
+Testing collisions (low  30-47 bits) - Worst is 47 bits: 28/26 (1.05x)
 Testing collisions (low  12-bit) - Expected   86532449.0, actual 86532449 (1.00x)
 Testing collisions (low   8-bit) - Expected   86536289.0, actual 86536289 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 60 - 0.003%
+Testing distribution - Worst bias is the 20-bit window at bit 47 - 0.004%
 
 
 [[[ Keyset 'Text' Tests ]]]
 
 Keyset 'Text' - keys of form "FooXXXXBar" - 14776336 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      25418.1, actual  25423 (1.00x) (5)
-Testing collisions (high 27-42 bits) - Worst is 36 bits: 1623/1588 (1.02x)
+Testing collisions (high 32-bit) - Expected      25418.1, actual  25360 (1.00x) (-58)
+Testing collisions (high 27-42 bits) - Worst is 42 bits: 28/24 (1.13x)
 Testing collisions (high 12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (high  8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing collisions (low  32-bit) - Expected      25418.1, actual  25763 (1.01x) (345)
-Testing collisions (low  27-42 bits) - Worst is 40 bits: 109/99 (1.10x)
+Testing collisions (low  32-bit) - Expected      25418.1, actual  25466 (1.00x) (48)
+Testing collisions (low  27-42 bits) - Worst is 37 bits: 860/794 (1.08x)
 Testing collisions (low  12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (low   8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 43 - 0.027%
+Testing distribution - Worst bias is the 19-bit window at bit 27 - 0.015%
 
 Keyset 'Text' - keys of form "FooBarXXXX" - 14776336 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      25418.1, actual  25554 (1.01x) (136)
-Testing collisions (high 27-42 bits) - Worst is 35 bits: 3239/3177 (1.02x)
+Testing collisions (high 32-bit) - Expected      25418.1, actual  25563 (1.01x) (145)
+Testing collisions (high 27-42 bits) - Worst is 41 bits: 55/49 (1.11x)
 Testing collisions (high 12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (high  8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing collisions (low  32-bit) - Expected      25418.1, actual  25478 (1.00x) (60)
-Testing collisions (low  27-42 bits) - Worst is 37 bits: 811/794 (1.02x)
+Testing collisions (low  32-bit) - Expected      25418.1, actual  25489 (1.00x) (71)
+Testing collisions (low  27-42 bits) - Worst is 42 bits: 28/24 (1.13x)
 Testing collisions (low  12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (low   8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit  9 - 0.021%
+Testing distribution - Worst bias is the 20-bit window at bit 58 - 0.028%
 
 Keyset 'Text' - keys of form "XXXXFooBar" - 14776336 keys
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected      25418.1, actual  25495 (1.00x) (77)
-Testing collisions (high 27-42 bits) - Worst is 39 bits: 217/198 (1.09x)
+Testing collisions (high 32-bit) - Expected      25418.1, actual  25376 (1.00x) (-42)
+Testing collisions (high 27-42 bits) - Worst is 42 bits: 28/24 (1.13x)
 Testing collisions (high 12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (high  8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing collisions (low  32-bit) - Expected      25418.1, actual  25340 (1.00x) (-78)
-Testing collisions (low  27-42 bits) - Worst is 36 bits: 1636/1588 (1.03x)
+Testing collisions (low  32-bit) - Expected      25418.1, actual  25376 (1.00x) (-42)
+Testing collisions (low  27-42 bits) - Worst is 41 bits: 54/49 (1.09x)
 Testing collisions (low  12-bit) - Expected   14772240.0, actual 14772240 (1.00x)
 Testing collisions (low   8-bit) - Expected   14776080.0, actual 14776080 (1.00x)
-Testing distribution - Worst bias is the 20-bit window at bit 59 - 0.018%
+Testing distribution - Worst bias is the 20-bit window at bit 34 - 0.032%
 
 Keyset 'Words' - 4000000 random keys of len 6-16 from alnum charset
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1862.6, actual   1924 (1.03x) (62)
-Testing collisions (high 25-38 bits) - Worst is 33 bits: 995/931 (1.07x)
+Testing collisions (high 32-bit) - Expected       1862.6, actual   1861 (1.00x) (-1)
+Testing collisions (high 25-38 bits) - Worst is 38 bits: 41/29 (1.41x)
 Testing collisions (high 12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (high  8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
-Testing collisions (low  32-bit) - Expected       1862.6, actual   1825 (0.98x)
-Testing collisions (low  25-38 bits) - Worst is 38 bits: 35/29 (1.20x)
+Testing collisions (low  32-bit) - Expected       1862.6, actual   1854 (1.00x) (-8)
+Testing collisions (low  25-38 bits) - Worst is 33 bits: 942/931 (1.01x)
 Testing collisions (low  12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (low   8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 24 - 0.070%
+Testing distribution - Worst bias is the 19-bit window at bit 25 - 0.055%
 
 Keyset 'Words' - 4000000 random keys of len 6-16 from password charset
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected       1862.6, actual   1939 (1.04x) (77)
-Testing collisions (high 25-38 bits) - Worst is 34 bits: 506/465 (1.09x)
+Testing collisions (high 32-bit) - Expected       1862.6, actual   1872 (1.01x) (10)
+Testing collisions (high 25-38 bits) - Worst is 38 bits: 33/29 (1.13x)
 Testing collisions (high 12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (high  8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
-Testing collisions (low  32-bit) - Expected       1862.6, actual   1843 (0.99x) (-19)
-Testing collisions (low  25-38 bits) - Worst is 31 bits: 3757/3725 (1.01x)
+Testing collisions (low  32-bit) - Expected       1862.6, actual   1841 (0.99x) (-21)
+Testing collisions (low  25-38 bits) - Worst is 29 bits: 14948/14901 (1.00x)
 Testing collisions (low  12-bit) - Expected    3995904.0, actual 3995904 (1.00x)
 Testing collisions (low   8-bit) - Expected    3999744.0, actual 3999744 (1.00x)
-Testing distribution - Worst bias is the 19-bit window at bit 51 - 0.048%
+Testing distribution - Worst bias is the 19-bit window at bit 49 - 0.069%
 
 Keyset 'Words' - 167303 dict words
 Testing collisions ( 64-bit) - Expected    0.0, actual      0 (0.00x)
-Testing collisions (high 32-bit) - Expected          3.3, actual      2 (0.61x)
-Testing collisions (high 21-29 bits) - Worst is 21 bits: 6528/6673 (0.98x)
+Testing collisions (high 32-bit) - Expected          3.3, actual      4 (1.23x) (1)
+Testing collisions (high 21-29 bits) - Worst is 22 bits: 3387/3336 (1.02x)
 Testing collisions (high 12-bit) - Expected     163207.0, actual 163207 (1.00x)
 Testing collisions (high  8-bit) - Expected     167047.0, actual 167047 (1.00x)
-Testing collisions (low  32-bit) - Expected          3.3, actual      3 (0.92x)
-Testing collisions (low  21-29 bits) - Worst is 27 bits: 113/104 (1.08x)
+Testing collisions (low  32-bit) - Expected          3.3, actual      2 (0.61x)
+Testing collisions (low  21-29 bits) - Worst is 23 bits: 1673/1668 (1.00x)
 Testing collisions (low  12-bit) - Expected     163207.0, actual 163207 (1.00x)
 Testing collisions (low   8-bit) - Expected     167047.0, actual 167047 (1.00x)
-Testing distribution - Worst bias is the 15-bit window at bit 32 - 0.420%
+Testing distribution - Worst bias is the 15-bit window at bit 63 - 0.306%
 
 
 [[[ Keyset 'Zeroes' Tests ]]]
@@ -725,7 +725,7 @@ Testing collisions (low  32-bit) - Expected          4.9, actual      5 (1.02x) 
 Testing collisions (low  21-29 bits) - Worst is 29 bits: 46/39 (1.18x)
 Testing collisions (low  12-bit) - Expected     200704.0, actual 200704 (1.00x)
 Testing collisions (low   8-bit) - Expected     204544.0, actual 204544 (1.00x)
-Testing distribution - Worst bias is the 15-bit window at bit 22 - 0.313%
+Testing distribution - Worst bias is the 15-bit window at bit 22 - 0.316%
 
 
 [[[ Keyset 'Seed' Tests ]]]
@@ -1512,5 +1512,5 @@ Testing collisions (low   8-bit) - Expected   33554176.0, actual 33554176 (1.00x
 
 
 Input vcode 0x00000001, Output vcode 0x00000001, Result vcode 0x00000001
-Verification value is 0x00000001 - Testing took 1797.635784 seconds
+Verification value is 0x00000001 - Testing took 1649.440477 seconds
 -------------------------------------------------------------------------------

--- a/t/test_umash_long.py
+++ b/t/test_umash_long.py
@@ -1,5 +1,5 @@
 """
-Test suite for the general (16 bytes or longer) input case.
+Test suite for the general (17 bytes or longer) input case.
 """
 from hypothesis import given, note
 import hypothesis.strategies as st
@@ -28,7 +28,7 @@ def repeats(min_size):
     key=st.lists(
         U64S, min_size=C.UMASH_PH_PARAM_COUNT, max_size=C.UMASH_PH_PARAM_COUNT
     ),
-    data=st.binary(min_size=16) | repeats(16),
+    data=st.binary(min_size=17) | repeats(17),
 )
 def test_umash_long(seed, multiplier, key, data):
     """Compare umash_long with the reference."""

--- a/umash.h
+++ b/umash.h
@@ -142,6 +142,10 @@ struct umash_sink {
 	/*
 	 * We write new bytes to the second half, and keep the previous
 	 * 16 byte chunk in the first half.
+	 *
+	 * We may temporarily have a full 16-byte buffer in the second half:
+	 * we must know if the first 16 byte chunk is the first of many, or
+	 * the whole input.
 	 */
 	char buf[2 * 16];
 


### PR DESCRIPTION
PH's CLMUL / xor gives better throughput than NH, with the latter's
mixed 64/128 bit arithmetic.  However, this comes at the expense of
latency.

Revert to NH for inputs of 9 to 16 bytes... which mixes less well
because we work in regular arithmetic for the block compressor and the
polynomial hash.  Reversibly xor the low NH half into the high half
before polynomial hashing, to break in bitwise linearity, and improve
distribution.

Improves latency on Kaby Lake by ~8 cycles (the better choice 90% of
the time), at the expense of what looks like codegen noise for 0-8
byte inputs.

```
[('0-7',
  {'mean': Result(actual_value=1.3653653653653655, judgement=1, m=20000, n=20000, num_trials=3500000),
   'lte': Result(actual_value=0.504397895, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'q99': Result(actual_value=13.0, judgement=0, m=20000, n=20000, num_trials=750),
   'q99_sa': Result(actual_value=13.0, judgement=0, m=20000, n=20000, num_trials=250)}),
 (8,
  {'mean': Result(actual_value=0.9511011011011011, judgement=0, m=20000, n=20000, num_trials=250),
   'lte': Result(actual_value=0.54585884, judgement=-1, m=20000, n=20000, num_trials=3250000),
   'q99': Result(actual_value=1.0, judgement=0, m=20000, n=20000, num_trials=250),
   'q99_sa': Result(actual_value=1.0, judgement=0, m=20000, n=20000, num_trials=250)}),
 ('9-15',
  {'mean': Result(actual_value=-8.087087087087086, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'lte': Result(actual_value=0.898433755, judgement=1, m=20000, n=20000, num_trials=2750000),
   'q99': Result(actual_value=-9.0, judgement=0, m=20000, n=20000, num_trials=1000),
   'q99_sa': Result(actual_value=-9.0, judgement=0, m=20000, n=20000, num_trials=47500)}),
 (16,
  {'mean': Result(actual_value=-8.239307535641547, judgement=-1, m=984, n=984, num_trials=2750000),
   'lte': Result(actual_value=0.8866405165576046, judgement=1, m=984, n=984, num_trials=2750000),
   'q99': Result(actual_value=-7.0, judgement=0, m=984, n=984, num_trials=250),
   'q99_sa': Result(actual_value=-7.0, judgement=0, m=984, n=984, num_trials=250)})]
```