### PR TITLE
umash: switch secondary hash to twisted version

### DIFF
--- a/t/test_params_prepare.py
+++ b/t/test_params_prepare.py
@@ -14,7 +14,7 @@ U64S = st.integers(min_value=0, max_value=2 ** 64 - 1)
 FIELD = 2 ** 61 - 1
 
 
-OH_COUNT = C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT
+OH_COUNT = C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT
 
 
 def assert_idempotent(params):
@@ -60,7 +60,7 @@ def test_public_multiplier_reduction(multipliers, random):
         assert params[0].poly[i][0] == (params[0].poly[i][1] ** 2) % FIELD
 
     # The OH params are valid.
-    for i in range(C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT):
+    for i in range(C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT):
         assert params[0].oh[i] == i
 
 
@@ -105,7 +105,7 @@ def test_public_smoke_matches(random, seed, data):
     """Prepare a params struct, and make sure the UMASH function matches
     our reference."""
     params = FFI.new("struct umash_params[1]")
-    size = size = FFI.sizeof("struct umash_params")
+    size = FFI.sizeof("struct umash_params")
     assert size % 8 == 0
     for i in range(size // 8):
         FFI.cast("uint64_t *", params)[i] = random.getrandbits(64)

--- a/t/test_umash_fprint.py
+++ b/t/test_umash_fprint.py
@@ -28,10 +28,9 @@ def repeats(min_size):
         st.integers(min_value=0, max_value=FIELD - 1), min_size=2, max_size=2
     ),
     key=st.lists(
-        # We need 4 more OH values for the Toeplitz shift.
         U64S,
-        min_size=C.UMASH_OH_PARAM_COUNT + 4,
-        max_size=C.UMASH_OH_PARAM_COUNT + 4,
+        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
     ),
     data=st.binary() | repeats(1),
 )

--- a/t/test_umash_full.py
+++ b/t/test_umash_full.py
@@ -18,8 +18,8 @@ FIELD = 2 ** 61 - 1
     multiplier=st.integers(min_value=0, max_value=FIELD - 1),
     key=st.lists(
         U64S,
-        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT,
-        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT,
+        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
     ),
     data=st.binary(),
 )
@@ -44,8 +44,8 @@ def test_public_umash_full(seed, multiplier, key, data):
     multiplier=st.integers(min_value=0, max_value=FIELD - 1),
     key=st.lists(
         U64S,
-        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT,
-        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT,
+        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
     ),
     data=st.binary(),
 )

--- a/t/test_umash_incremental.py
+++ b/t/test_umash_incremental.py
@@ -38,8 +38,8 @@ def umash_params():
         st.lists(st.integers(min_value=0, max_value=FIELD - 1), min_size=2, max_size=2),
         st.lists(
             U64S,
-            min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT,
-            max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT,
+            min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+            max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
         ),
     )
 

--- a/t/test_umash_long.py
+++ b/t/test_umash_long.py
@@ -27,8 +27,8 @@ def repeats(min_size):
     multiplier=st.integers(min_value=0, max_value=FIELD - 1),
     key=st.lists(
         U64S,
-        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT,
-        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT,
+        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
     ),
     data=st.binary(min_size=16) | repeats(16),
 )
@@ -55,8 +55,8 @@ def test_umash_long(seed, multiplier, key, data):
     multiplier=st.integers(min_value=0, max_value=FIELD - 1),
     key=st.lists(
         U64S,
-        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT,
-        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT,
+        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
     ),
     data=repeats(512),
 )

--- a/t/test_umash_medium.py
+++ b/t/test_umash_medium.py
@@ -18,8 +18,8 @@ FIELD = 2 ** 61 - 1
     multiplier=st.integers(min_value=0, max_value=FIELD - 1),
     key=st.lists(
         U64S,
-        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT,
-        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT,
+        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
     ),
     data=st.binary(min_size=9, max_size=16),
 )

--- a/t/test_umash_short.py
+++ b/t/test_umash_short.py
@@ -24,8 +24,8 @@ def test_vec_to_u64(data):
     seed=U64S,
     key=st.lists(
         U64S,
-        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT,
-        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TOEPLITZ_SHIFT,
+        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
     ),
     data=st.binary(min_size=0, max_size=8),
 )

--- a/umash.h
+++ b/umash.h
@@ -92,7 +92,7 @@
 extern "C" {
 #endif
 
-enum { UMASH_OH_PARAM_COUNT = 32, UMASH_OH_TOEPLITZ_SHIFT = 4 };
+enum { UMASH_OH_PARAM_COUNT = 32, UMASH_OH_TWISTING_COUNT = 2 };
 
 /**
  * A single UMASH params struct stores the parameters for a pair of
@@ -105,10 +105,10 @@ struct umash_params {
 	 */
 	uint64_t poly[2][2];
 	/*
-	 * The second OH function starts reading parameters from the
-	 * fourth 64-bit element.
+	 * The second (twisted) OH function uses an additional
+	 * 128-bit constant stored in the last two elements.
 	 */
-	uint64_t oh[UMASH_OH_PARAM_COUNT + UMASH_OH_TOEPLITZ_SHIFT];
+	uint64_t oh[UMASH_OH_PARAM_COUNT + UMASH_OH_TWISTING_COUNT];
 };
 
 /**
@@ -172,7 +172,12 @@ struct umash_sink {
 	/* Accumulators for the current OH value. */
 	struct umash_oh {
 		uint64_t bits[2];
-	} oh_acc[2];
+	} oh_acc;
+	struct umash_twisted_oh {
+		uint64_t lrc[2];
+		uint64_t prev[2];
+		struct umash_oh acc;
+	} oh_twisted;
 
 	uint64_t seed;
 };


### PR DESCRIPTION
described in http://pvk.ca/Blog/2020/10/31/nearly-double-the-ph-bits-with-one-more-clmul/

It's now slightly more work to compute the secondary hash by itself,
but almost half as much work when we compute a full fingerprint.

This already helps short input latency, but throughput improvements
aren't in this commit.  A hackily souped up version did confirm that
we can at least match the current throughput, and it seems reasonable
to think the new algorithm is better able to use 256- or 512- bit
vectors.

Closes #16; we now have a stable algorithm: the 64-bit hash hasn't changed
since october 12th, and the new fingerprint algorithm should eventually be almost
as fast as the hash.