### PR TITLE
umash: get rid of the full-block OH compressor

### DIFF
--- a/t/test_oh.py
+++ b/t/test_oh.py
@@ -27,7 +27,7 @@ def split_block(data):
     ),
     data=st.binary(min_size=BLOCK_SIZE, max_size=BLOCK_SIZE),
 )
-def test_oh_one_block(tag, key, data):
+def test_oh_full_block(tag, key, data):
     """Compare OH compression for full blocks."""
     # The C-side implicit accepts the high half of the tag, and leaves
     # the low half zeroed out.
@@ -40,7 +40,7 @@ def test_oh_one_block(tag, key, data):
     for i, param in enumerate(key):
         params[0].oh[i] = param
 
-    actual = C.oh_one_block(params[0].oh, tag, block)
+    actual = C.oh_varblock(params[0].oh, tag, block, BLOCK_SIZE)
     assert expected == actual.bits[0] + (actual.bits[1] << 64), (
         actual.bits[0],
         actual.bits[1],
@@ -56,7 +56,7 @@ def test_oh_one_block(tag, key, data):
     ),
     data=st.binary(min_size=BLOCK_SIZE, max_size=BLOCK_SIZE),
 )
-def test_oh_one_block_fprint(tag, key, data):
+def test_oh_full_block_fprint(tag, key, data):
     """Compare combined OH compression for full blocks."""
     expected = [
         oh_compress_one_block(key, split_block(data), tag << 64),
@@ -71,7 +71,7 @@ def test_oh_one_block_fprint(tag, key, data):
         params[0].oh[i] = param
 
     actual = FFI.new("struct umash_oh[2]")
-    C.oh_one_block_fprint(actual, params[0].oh, tag, block)
+    C.oh_varblock_fprint(actual, params[0].oh, tag, block, BLOCK_SIZE)
     assert expected == [
         (actual[0].bits[0] + (actual[0].bits[1] << 64)),
         (actual[1].bits[0] + (actual[1].bits[1] << 64)),
@@ -103,7 +103,7 @@ def test_oh_tail_large(tag, key, data):
     for i, param in enumerate(key):
         params[0].oh[i] = param
 
-    actual = C.oh_last_block(params[0].oh, tag, block, n_bytes)
+    actual = C.oh_varblock(params[0].oh, tag, block, n_bytes)
     assert expected == actual.bits[0] + (actual.bits[1] << 64), (
         actual.bits[0],
         actual.bits[1],
@@ -137,7 +137,7 @@ def test_oh_tail_large_fprint(tag, key, data):
         params[0].oh[i] = param
 
     actual = FFI.new("struct umash_oh[2]")
-    C.oh_last_block_fprint(actual, params[0].oh, tag, block, n_bytes)
+    C.oh_varblock_fprint(actual, params[0].oh, tag, block, n_bytes)
     assert expected == [
         (actual[0].bits[0] + (actual[0].bits[1] << 64)),
         (actual[1].bits[0] + (actual[1].bits[1] << 64)),
@@ -173,7 +173,7 @@ def test_oh_tail_short(tag, key, prefix, data):
     for i, param in enumerate(key):
         params[0].oh[i] = param
 
-    actual = C.oh_last_block(params[0].oh, tag, block + offset, n_bytes)
+    actual = C.oh_varblock(params[0].oh, tag, block + offset, n_bytes)
     assert expected == actual.bits[0] + (actual.bits[1] << 64), (
         actual.bits[0],
         actual.bits[1],
@@ -215,7 +215,7 @@ def test_oh_tail_short_fprint(tag, key, prefix, data):
         params[0].oh[i] = param
 
     actual = FFI.new("struct umash_oh[2]")
-    C.oh_last_block_fprint(actual, params[0].oh, tag, block + offset, n_bytes)
+    C.oh_varblock_fprint(actual, params[0].oh, tag, block + offset, n_bytes)
     assert expected == [
         (actual[0].bits[0] + (actual[0].bits[1] << 64)),
         (actual[1].bits[0] + (actual[1].bits[1] << 64)),

--- a/t/umash_test_only.h
+++ b/t/umash_test_only.h
@@ -40,30 +40,19 @@ uint64_t horner_double_update(
     uint64_t acc, uint64_t m0, uint64_t m1, uint64_t x, uint64_t y);
 
 /**
- * Compresses one OH block of 256 bytes.
+ * Compress one OH block of up to 256 bytes.  `block + n_bytes - 16`
+ * must contain input data (i.e., the function will read behind to
+ * backfill to a round 16 bytes).
  */
-struct umash_oh oh_one_block(const uint64_t *params, uint64_t tag, const void *block);
-
-/**
- * Compresses one OH block of 256 bytes with the primary and secondary
- * compressors.
- */
-void oh_one_block_fprint(struct umash_oh dst[static 2], const uint64_t *restrict params,
-    uint64_t tag, const void *restrict block);
-
-/**
- * Compress the last OH block of up to 256 bytes.  `block + n_bytes -
- * 16` must contain input data.
- */
-struct umash_oh oh_last_block(
+struct umash_oh oh_varblock(
     const uint64_t *params, uint64_t tag, const void *block, size_t n_bytes);
 
 /**
- * Compress the last OH block of up to 256 bytes with the primary and
+ * Compress one OH block of up to 256 bytes with the primary and
  * secondary compressors.  `block + n_bytes - 16` must contain input
- * data.
+ * data (i.e., the function will read behind to backfill to 16 bytes).
  */
-void oh_last_block_fprint(struct umash_oh dst[static 2], const uint64_t *restrict params,
+void oh_varblock_fprint(struct umash_oh dst[static 2], const uint64_t *restrict params,
     uint64_t tag, const void *restrict block, size_t n_bytes);
 
 /**


### PR DESCRIPTION
Turns out it's faster to always use the variable-length compressor on
a EPYC 7713... and we'll add *really* specialised code for long input
soon.  In the meantime, less code and I$ pressure is a definite win.

Closes #19.

TESTED=unit tests, and performance testing notebooks.