### PR TITLE
umash_long.inc: new optional file for long (>= 1KB) hash inputs

### DIFF
--- a/t/format.sh
+++ b/t/format.sh
@@ -2,5 +2,5 @@
 set -e
 BASE=$(dirname "$0")
 
-clang-format -i "${BASE}/../"*.[ch] "${BASE}/"*.h "${BASE}/../bench/"*.[ch]
+clang-format -i "${BASE}/../"*.[ch] "${BASE}/../"*.inc "${BASE}/"*.h "${BASE}/../bench/"*.[ch]
 clang-format --style=google -i "${BASE}/../bench/protos/"*.proto

--- a/t/run-tests-public.sh
+++ b/t/run-tests-public.sh
@@ -5,7 +5,7 @@ PYTHON=${PYTHON3:-python3}
 
 (cd "${BASE}/../";
  ${CC:-cc} ${CFLAGS:- -O2 -std=c99 -W -Wall -mpclmul} umash.c \
-           '-DUMASH_SECTION="umash_text"' \
+            -DUMASH_LONG_INPUTS=1 '-DUMASH_SECTION="umash_text"' \
 	   -fPIC --shared -o libumash.so)
 
 OUT_OF_SECTION_SYMS=$(

--- a/t/run-tests.sh
+++ b/t/run-tests.sh
@@ -4,7 +4,8 @@ BASE=$(dirname $(readlink -f "$0"))
 PYTHON=${PYTHON3:-python3}
 
 (cd "${BASE}/../";
- ${CC:-cc} ${CFLAGS:- -g -O2 -std=c99 -W -Wall -mpclmul} -DUMASH_TEST_ONLY umash.c \
+ ${CC:-cc} ${CFLAGS:- -g -O2 -std=c99 -W -Wall -mpclmul} \
+           -DUMASH_TEST_ONLY -DUMASH_LONG_INPUTS=0 umash.c \
            '-DUMASH_SECTION="umash_text"' \
 	   -fPIC --shared -o umash_test_only.so;
  ${CC:-cc} ${CFLAGS:- -O2 -std=c99 -W -Wall -mpclmul} -c example.c -o /dev/null;

--- a/t/test_umash_multiple_blocks.py
+++ b/t/test_umash_multiple_blocks.py
@@ -1,0 +1,113 @@
+"""
+Test suite for the very long input subroutine.
+"""
+from hypothesis import given, note
+import hypothesis.strategies as st
+from umash import C, FFI
+from umash_reference import (
+    blockify_chunks,
+    chunk_bytes,
+    oh_compress,
+    poly_reduce,
+    UmashKey,
+)
+
+
+U64S = st.integers(min_value=0, max_value=2**64 - 1)
+
+
+FIELD = 2**61 - 1
+
+
+def repeats(size):
+    """Repeats one byte exactly size times."""
+    return st.binary(min_size=1, max_size=1).map(lambda binary: binary * size)
+
+
+def multiple_blocks_reference(key, initial, seed, data):
+    blocks = blockify_chunks(chunk_bytes(data))
+    oh_values = oh_compress(key.oh, seed, blocks, secondary=False)
+    return poly_reduce(key.poly, len(data), oh_values, initial)
+
+
+@given(
+    initial=U64S,
+    seed=U64S,
+    multiplier=st.integers(min_value=0, max_value=FIELD - 1),
+    key=st.lists(
+        U64S,
+        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+    ),
+    data=repeats(256)
+    | repeats(512)
+    | st.binary(min_size=256, max_size=256)
+    | st.binary(min_size=512, max_size=512),
+)
+def test_umash_multiple_blocks(initial, seed, multiplier, key, data):
+    """Compare umash_multiple_blocks with the reference on short inputs:
+    we only invoke `umash_multiple_blocks` on large inputs purely for
+    performance reasons.  With respect to pure correctness, it should
+    be OK to invoke on any number of integral blocks.
+    """
+    assert len(data) % 256 == 0
+    expected = multiple_blocks_reference(
+        UmashKey(poly=multiplier, oh=key), initial, seed, data
+    )
+    note(len(data))
+
+    n_bytes = len(data)
+    block = FFI.new("char[]", n_bytes)
+    FFI.memmove(block, data, n_bytes)
+    poly = FFI.new("uint64_t[2]")
+    poly[0] = (multiplier**2) % FIELD
+    poly[1] = multiplier
+    params = FFI.new("struct umash_params[1]")
+    for i, param in enumerate(key):
+        params[0].oh[i] = param
+
+    assert (
+        C.umash_multiple_blocks(
+            initial, poly, params[0].oh, seed, block, n_bytes // 256
+        )
+        == expected
+    )
+
+
+@given(
+    initial=U64S,
+    seed=U64S,
+    multiplier=st.integers(min_value=0, max_value=FIELD - 1),
+    key=st.lists(
+        U64S,
+        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+    ),
+    data=st.lists(repeats(256), min_size=3, max_size=10).map(
+        lambda chunks: b"".join(chunks)
+    ),
+)
+def test_umash_multiple_blocks_repeat(initial, seed, multiplier, key, data):
+    """Compare umash_multiple_blocks with the reference on longer inputs."""
+    assert len(data) % 256 == 0
+    expected = multiple_blocks_reference(
+        UmashKey(poly=multiplier, oh=key), initial, seed, data
+    )
+    note(len(data))
+
+    n_bytes = len(data)
+    block = FFI.new("char[]", n_bytes)
+    FFI.memmove(block, data, n_bytes)
+    poly = FFI.new("uint64_t[2]")
+    poly[0] = (multiplier**2) % FIELD
+    poly[1] = multiplier
+    params = FFI.new("struct umash_params[1]")
+    for i, param in enumerate(key):
+        params[0].oh[i] = param
+
+    assert (
+        C.umash_multiple_blocks(
+            initial, poly, params[0].oh, seed, block, n_bytes // 256
+        )
+        == expected
+    )

--- a/t/umash_test_only.h
+++ b/t/umash_test_only.h
@@ -55,6 +55,9 @@ struct umash_oh oh_varblock(
 void oh_varblock_fprint(struct umash_oh dst[static 2], const uint64_t *restrict params,
     uint64_t tag, const void *restrict block, size_t n_bytes);
 
+uint64_t umash_multiple_blocks(uint64_t initial, const uint64_t multipliers[static 2],
+    const uint64_t *oh_ptr, uint64_t seed, const void *blocks, size_t n_blocks);
+
 /**
  * Converts a buffer of <= 8 bytes to a 64-bit integers.
  */

--- a/umash_long.inc
+++ b/umash_long.inc
@@ -1,0 +1,92 @@
+/* -*- mode: c; -*- vim: set ft=c: */
+
+/**
+ * More wasteful routine for longer inputs (that can absorb I$ misses
+ * and fixed setup work).
+ */
+#if UMASH_LONG_INPUTS
+/*
+ * Minimum byte size before switching to `umash_multiple_blocks`.
+ *
+ * Leaving this variable undefined disable calls to
+ * `umash_multiple_blocks.
+ */
+#define UMASH_MULTIPLE_BLOCKS_THRESHOLD 1024
+#endif
+
+/**
+ * Updates a 64-bit UMASH state for `n_blocks` 256-byte blocks in data.
+ */
+TEST_DEF HOT uint64_t
+umash_multiple_blocks(uint64_t initial, const uint64_t multipliers[static 2],
+    const uint64_t *oh_ptr, uint64_t seed, const void *blocks, size_t n_blocks)
+{
+	uint64_t params[UMASH_OH_PARAM_COUNT] __attribute__((__aligned__(16)));
+	const uint64_t m0 = multipliers[0];
+	const uint64_t m1 = multipliers[1];
+	uint64_t ret = initial;
+
+	memcpy(params, oh_ptr, sizeof(params));
+
+	for (size_t block_count = 0; block_count < n_blocks; block_count++) {
+		const void *data = blocks;
+		struct umash_oh oh;
+		v128 acc = V128_ZERO;
+
+		blocks = (const char *)blocks + BLOCK_SIZE;
+
+#define PH(I)                                          \
+	do {                                           \
+		v128 x, k;                             \
+                                                       \
+		memcpy(&x, data, sizeof(x));           \
+		data = (const char *)data + sizeof(x); \
+                                                       \
+		memcpy(&k, &params[I], sizeof(k));     \
+		x ^= k;                                \
+		acc ^= v128_clmul_cross(x);            \
+	} while (0)
+
+		PH(0);
+		PH(2);
+		PH(4);
+		PH(6);
+		PH(8);
+		PH(10);
+		PH(12);
+		PH(14);
+		PH(16);
+		PH(18);
+		PH(20);
+		PH(22);
+		PH(24);
+		PH(26);
+		PH(28);
+
+#undef PH
+
+		memcpy(&oh, &acc, sizeof(oh));
+
+		/* Final ENH chunk. */
+		{
+			__uint128_t enh = (__uint128_t)seed << 64;
+			uint64_t x, y;
+
+			memcpy(&x, data, sizeof(x));
+			data = (const char *)data + sizeof(x);
+			memcpy(&y, data, sizeof(y));
+			data = (const char *)data + sizeof(y);
+
+			x += params[30];
+			y += params[31];
+			enh += (__uint128_t)x * y;
+
+			oh.bits[0] ^= (uint64_t)enh;
+			oh.bits[1] ^= (uint64_t)(enh >> 64) ^ (uint64_t)enh;
+		}
+
+		ret = horner_double_update(ret, m0, m1, oh.bits[0], oh.bits[1]);
+	}
+
+	return ret;
+}

--- a/umash_reference.py
+++ b/umash_reference.py
@@ -1149,7 +1149,7 @@ def oh_compress_one_block(key, block, tag, secondary=False):
     return acc
 
 
-def oh_compress(key, seed, blocks, secondary):
+def oh_compress(key, seed, blocks, secondary=False):
     """Applies the `OH` compression function to each block; generates
     a stream of compressed values"""
     for block, block_size in blocks:
@@ -1190,13 +1190,13 @@ def oh_compress(key, seed, blocks, secondary):
 ## last step be a multiplication helps satisfy SMHasher.
 
 
-def poly_reduce(multiplier, input_size, compressed_values):
+def poly_reduce(multiplier, input_size, compressed_values, initial=0):
     """Updates a polynomial hash with the `OH` compressed outputs."""
     # Square the multiplier and fully reduce it. This does not affect
     # the result modulo 2**61 - 1, but does differ from a
     # direct evaluation modulo 2**64 - 8.
     mulsq = (multiplier ** 2) % (2 ** 61 - 1)
-    acc = [0]
+    acc = [initial]
 
     def update(y0, y1):
         """Double-pumped Horner update (mostly) modulo 8 * (2**61 - 1)."""


### PR DESCRIPTION
The new function umash_multiple_blocks is unrolled and optimised for
long inputs.  In production traces, string hashes > 512 bytes were
virtually inexistent.  It seems safe to trigger this new code path
when hashing at least 4 blocks of 256 bytes: the distribution of
input sizes probably has a very fat tail once we pass that threshold
(certainly true for Verneuil, which hashes and fingerprints a lot of
64 KB buffers).

Maybe not everyone will want the extra code size, so the new file is
optional: by default, `umash.c` will include `umash_long.inc` when
it's available, and otherwise disable the new code path.

This does mean more code paths, which is unfortunate.  The full tests
(`t/run-tests.sh`) will now build `umash_long.inc`, but not use it,
except for tests that explicitly call `umash_multiple_blocks`.  The
public interface tests (`t/run-tests-public.sh`) instead always test
umash with the new code path enabled.

First step of #21.

TESTED=new and existing tests.