### PR TITLE
umash_long.inc: dispatch to AVX2 / VPCLMULQDQ version at runtime

### DIFF
--- a/umash_long.inc
+++ b/umash_long.inc
@@ -35,7 +35,10 @@ TEST_DEF umash_multiple_blocks_fn umash_multiple_blocks_generic;
  * always forwards to `umash_multiple_blocks_generic`.
  */
 #if defined(__x86_64__) && UMASH_DYNAMIC_DISPATCH
-static umash_multiple_blocks_fn umash_multiple_blocks_pick;
+#include <cpuid.h>
+
+static umash_multiple_blocks_fn umash_multiple_blocks_pick,
+    umash_multiple_blocks_vpclmulqdq;
 
 static umash_multiple_blocks_fn *umash_multiple_blocks_impl = umash_multiple_blocks_pick;
 
@@ -43,7 +46,29 @@ static COLD FN uint64_t
 umash_multiple_blocks_pick(uint64_t initial, const uint64_t multipliers[static 2],
     const uint64_t *oh_ptr, uint64_t seed, const void *blocks, size_t n_blocks)
 {
-	umash_multiple_blocks_impl = umash_multiple_blocks_generic;
+	bool has_vpclmulqdq = false;
+
+	{
+		const uint32_t extended_features_level = 7;
+		const uint32_t vpclmulqdq_bit = 1UL << 10;
+		uint32_t eax, ebx, ecx, edx;
+
+		eax = ebx = ecx = edx = 0;
+		__asm__("cpuid" : "+a"(eax), "+b"(ebx), "+c"(ecx), "+d"(edx));
+		if (eax >= extended_features_level) {
+			eax = extended_features_level;
+			ebx = ecx = edx = 0;
+			__asm__("cpuid" : "+a"(eax), "+b"(ebx), "+c"(ecx), "+d"(edx));
+			has_vpclmulqdq = (ecx & vpclmulqdq_bit) != 0;
+		}
+	}
+
+	if (has_vpclmulqdq) {
+		umash_multiple_blocks_impl = umash_multiple_blocks_vpclmulqdq;
+	} else {
+		umash_multiple_blocks_impl = umash_multiple_blocks_generic;
+	}
+
 	return umash_multiple_blocks_impl(
 	    initial, multipliers, oh_ptr, seed, blocks, n_blocks);
 }
@@ -162,3 +187,110 @@ umash_multiple_blocks_generic(uint64_t initial, const uint64_t multipliers[stati
 
 	return ret;
 }
+
+#if defined(__x86_64__) && UMASH_DYNAMIC_DISPATCH
+/**
+ * Updates a 64-bit UMASH state for `n_blocks` 256-byte blocks in data.
+ */
+TEST_DEF HOT __attribute__((__target__(("avx2,vpclmulqdq")))) uint64_t
+umash_multiple_blocks_vpclmulqdq(uint64_t initial, const uint64_t multipliers[static 2],
+    const uint64_t *oh_ptr, uint64_t seed, const void *blocks, size_t n_blocks)
+{
+	/*
+	 * This type represents unaligned AVX2-sized regions of
+	 * memory.
+	 */
+	struct b256 {
+		char bytes[32];
+	};
+
+	const uint64_t m0 = multipliers[0];
+	const uint64_t m1 = multipliers[1];
+	__m256i k0, k4, k8, k12, k16, k20, k24;
+	v128 k28;
+	const uint64_t kx = oh_ptr[UMASH_OH_PARAM_COUNT - 2];
+	const uint64_t ky = oh_ptr[UMASH_OH_PARAM_COUNT - 1];
+	uint64_t ret = initial;
+
+	assert(n_blocks > 0);
+
+#define LOADU(DST, PTR) \
+	__asm__("vmovdqu %1, %0" : "=x"(DST) : "m"(*(const struct b256 *)PTR))
+
+	LOADU(k0, &oh_ptr[0]);
+	LOADU(k4, &oh_ptr[4]);
+	LOADU(k8, &oh_ptr[8]);
+	LOADU(k12, &oh_ptr[12]);
+	LOADU(k16, &oh_ptr[16]);
+	LOADU(k20, &oh_ptr[20]);
+	LOADU(k24, &oh_ptr[24]);
+	memcpy(&k28, &oh_ptr[28], sizeof(k28));
+
+	do {
+		const void *data = blocks;
+		struct umash_oh oh;
+		__m256i acc2 = _mm256_setzero_si256();
+
+		blocks = (const char *)blocks + BLOCK_SIZE;
+
+#define PH(I)                                          \
+	do {                                           \
+		__m256i x;                             \
+                                                       \
+		LOADU(x, data);                        \
+		data = (const char *)data + sizeof(x); \
+                                                       \
+		x = _mm256_xor_si256(x, k##I);         \
+		x = _mm256_clmulepi64_epi128(x, x, 1); \
+		acc2 = _mm256_xor_si256(acc2, x);      \
+	} while (0)
+
+		PH(0);
+		PH(4);
+		PH(8);
+		PH(12);
+		PH(16);
+		PH(20);
+		PH(24);
+
+#undef PH
+#undef LOADU
+
+		{
+			v128 x;
+
+			memcpy(&x, data, sizeof(x));
+			data = (const char *)data + sizeof(x);
+			x ^= k28;
+			x = v128_clmul_cross(x);
+
+			x ^= _mm256_extracti128_si256(acc2, 0) ^
+			    _mm256_extracti128_si256(acc2, 1);
+
+			memcpy(&oh, &x, sizeof(oh));
+		}
+
+		/* Final ENH chunk. */
+		{
+			__uint128_t enh = (__uint128_t)seed << 64;
+			uint64_t x, y;
+
+			memcpy(&x, data, sizeof(x));
+			data = (const char *)data + sizeof(x);
+			memcpy(&y, data, sizeof(y));
+			data = (const char *)data + sizeof(y);
+
+			x += kx;
+			y += ky;
+			enh += (__uint128_t)x * y;
+
+			oh.bits[0] ^= (uint64_t)enh;
+			oh.bits[1] ^= (uint64_t)(enh >> 64) ^ (uint64_t)enh;
+		}
+
+		ret = horner_double_update(ret, m0, m1, oh.bits[0], oh.bits[1]);
+	} while (--n_blocks);
+
+	return ret;
+}
+#endif


### PR DESCRIPTION
Detect at runtime whether the 256-bit VPCLMULDQD instruction is
available, and divert long UMASH calls to the VPCLMULQDQ
implementation when possible.

That implementation is ~35% faster on an EPYC 7713, but can only be
used when VPCLMULQDQ is available.

Improves UMASH performance on long inputs (#21).

TESTED=existing tests.