### PR TITLE
umash_long: use partially reduced accumulator for the Horner poly

### DIFF
--- a/t/umash_test_only.h
+++ b/t/umash_test_only.h
@@ -39,6 +39,23 @@ uint64_t mul_mod_fast(uint64_t m, uint64_t x);
 uint64_t horner_double_update(
     uint64_t acc, uint64_t m0, uint64_t m1, uint64_t x, uint64_t y);
 
+struct split_accumulator {
+	uint64_t base;
+	uint64_t fixup;
+};
+
+/**
+ * Reduces the split accumulator's value to a value < 2**64 - 8.
+ */
+uint64_t split_accumulator_eval(struct split_accumulator acc);
+
+/**
+ * Returns the updated version of `acc` after a double-pumped Horner
+ * update: acc = m0 * (acc + h0) + m1 * h1 (mod 2**64 - 8).
+ */
+struct split_accumulator split_accumulator_update(const struct split_accumulator acc,
+    const uint64_t m0, const uint64_t m1, uint64_t h0, const uint64_t h1);
+
 /**
  * Compress one OH block of up to 256 bytes.  `block + n_bytes - 16`
  * must contain input data (i.e., the function will read behind to

--- a/umash_long.inc
+++ b/umash_long.inc
@@ -155,6 +155,25 @@ split_accumulator_update(const struct split_accumulator acc, const uint64_t m0,
 
 	mul128(partial, m0, &hi0, &lo0);
 
+#if defined(__x86_64__) && UMASH_INLINE_ASM
+	{
+		uint8_t cf0, cf1;
+
+		__asm__("addq %3, %0"
+			: "=r"(sum), "=@ccc"(cf0)
+			: "%0"(lo0), "r"(lo1)
+			: "cc");
+
+		hi = hi0 + hi1;
+
+		__asm__("shlq $3, %0" : "+r"(hi), "=@ccc"(cf1) : : "cc");
+		__asm__("addq %3, %0\n\t"
+			"adcb %5, %1"
+			: "=r"(sum), "=r"(fixup)
+			: "%0"(sum), "r"(hi), "%1"(cf0), "r"(cf1)
+			: "cc");
+	}
+#else
 	fixup = __builtin_uaddll_overflow(lo0, lo1, &sum);
 
 	assert(hi0 < (1UL << 61));
@@ -166,6 +185,8 @@ split_accumulator_update(const struct split_accumulator acc, const uint64_t m0,
 	hi *= 8;
 
 	fixup += __builtin_uaddll_overflow(sum, hi, &sum);
+#endif
+
 	return (struct split_accumulator) {
 		.base = sum,
 		.fixup = fixup,

--- a/umash_long.inc
+++ b/umash_long.inc
@@ -100,6 +100,78 @@ umash_multiple_blocks(uint64_t initial, const uint64_t multipliers[static 2],
 }
 #endif
 
+#define SPLIT_ACCUMULATOR_MAX_FIXUP 3
+
+/**
+ * A split accumulator represents a value (mod 2**64 - 8) as the
+ * evaluated sum `base + 8 * fixup`, where `fixup <=
+ * SPLIT_ACCUMULATOR_MAX_FIXUP`
+ */
+#ifndef UMASH_TEST_ONLY /* Also defined in `umash_test_only.h` */
+struct split_accumulator {
+	uint64_t base;
+	uint64_t fixup;
+};
+#endif
+
+/**
+ * Reduces the split accumulator's value to a value < 2**64 - 8.
+ */
+TEST_DEF inline uint64_t
+split_accumulator_eval(struct split_accumulator acc)
+{
+	return add_mod_slow(acc.base, 8 * acc.fixup);
+}
+
+/**
+ * Returns the updated version of `acc` after a double-pumped Horner
+ * update: acc = m0 * (acc + h0) + m1 * h1 (mod 2**64 - 8).
+ */
+TEST_DEF inline struct split_accumulator
+split_accumulator_update(const struct split_accumulator acc, const uint64_t m0,
+    const uint64_t m1, uint64_t h0, const uint64_t h1)
+{
+	uint64_t partial;
+	uint64_t lo0, hi0, lo1, hi1;
+	uint64_t hi;
+	unsigned long long sum;
+	int8_t fixup;
+
+	mul128(m1, h1, &hi1, &lo1);
+
+	/* partial \eqv (acc.base + h0 + 8 * acc.fixup)  mod 2**64 - 8 */
+	if (UNLIKELY(h0 > -8ULL * (SPLIT_ACCUMULATOR_MAX_FIXUP + 1))) {
+		h0 = add_mod_slow(h0, 8 * acc.fixup);
+	} else {
+		/*
+		 * h0 is a hash value, so it's unlikely to be
+		 * extremely high.  In the common case, this addition
+		 * doesn't overflows.
+		 */
+		h0 += 8 * acc.fixup;
+	}
+
+	partial = add_mod_fast(acc.base, h0);
+
+	mul128(partial, m0, &hi0, &lo0);
+
+	fixup = __builtin_uaddll_overflow(lo0, lo1, &sum);
+
+	assert(hi0 < (1UL << 61));
+	assert(hi1 < (1UL << 61));
+	/* hi0 and hi1 < 2**61, so this addition never overflows. */
+	hi = hi0 + hi1;
+
+	fixup += (hi & (1ULL << 61)) != 0;
+	hi *= 8;
+
+	fixup += __builtin_uaddll_overflow(sum, hi, &sum);
+	return (struct split_accumulator) {
+		.base = sum,
+		.fixup = fixup,
+	};
+}
+
 TEST_DEF HOT uint64_t
 umash_multiple_blocks_generic(uint64_t initial, const uint64_t multipliers[static 2],
     const uint64_t *oh_ptr, uint64_t seed, const void *blocks, size_t n_blocks)
@@ -108,7 +180,7 @@ umash_multiple_blocks_generic(uint64_t initial, const uint64_t multipliers[stati
 	const uint64_t m1 = multipliers[1];
 	const uint64_t kx = oh_ptr[UMASH_OH_PARAM_COUNT - 2];
 	const uint64_t ky = oh_ptr[UMASH_OH_PARAM_COUNT - 1];
-	uint64_t ret = initial;
+	struct split_accumulator ret = { .base = initial };
 
 	assert(n_blocks > 0);
 
@@ -197,10 +269,10 @@ umash_multiple_blocks_generic(uint64_t initial, const uint64_t multipliers[stati
 			oh.bits[1] ^= enh_hi ^ enh_lo;
 		}
 
-		ret = horner_double_update(ret, m0, m1, oh.bits[0], oh.bits[1]);
+		ret = split_accumulator_update(ret, m0, m1, oh.bits[0], oh.bits[1]);
 	} while (--n_blocks);
 
-	return ret;
+	return split_accumulator_eval(ret);
 }
 
 #if defined(__x86_64__) && UMASH_DYNAMIC_DISPATCH
@@ -217,7 +289,7 @@ umash_multiple_blocks_vpclmulqdq(uint64_t initial, const uint64_t multipliers[st
 	v128 k28;
 	const uint64_t kx = oh_ptr[UMASH_OH_PARAM_COUNT - 2];
 	const uint64_t ky = oh_ptr[UMASH_OH_PARAM_COUNT - 1];
-	uint64_t ret = initial;
+	struct split_accumulator ret = { .base = initial };
 
 	assert(n_blocks > 0);
 
@@ -307,9 +379,9 @@ umash_multiple_blocks_vpclmulqdq(uint64_t initial, const uint64_t multipliers[st
 			oh.bits[1] ^= enh_hi ^ enh_lo;
 		}
 
-		ret = horner_double_update(ret, m0, m1, oh.bits[0], oh.bits[1]);
+		ret = split_accumulator_update(ret, m0, m1, oh.bits[0], oh.bits[1]);
 	} while (--n_blocks);
 
-	return ret;
+	return split_accumulator_eval(ret);
 }
 #endif


### PR DESCRIPTION
We can expose new opportunities for micro-optimisation by representing the accumulator as an unevaluated sum of a u64 and a small fixup.

Compared to trunk on an unloaded EPYC 7713 on large (64 KB) inputs: 5980 -> 5740 cycles (11.0 b/c -> 11.4  b/c)

![newplot (13)](https://user-images.githubusercontent.com/704703/155564073-dbb08bfe-4ae6-4a2c-b539-b10492839eb4.png)

```
[(65536,
  {'mean': Result(actual_value=-250.97497497497497, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'lte': Result(actual_value=0.99505566, judgement=1, m=20000, n=20000, num_trials=2750000),
   'q99': Result(actual_value=-240.0, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'q99_sa': Result(actual_value=-240.0, judgement=-1, m=20000, n=20000, num_trials=2750000)})]
```