### PR TITLE
umash_long: add a fingerprint function for multiple blocks

### DIFF
--- a/t/test_umash_fp_multiple_blocks.py
+++ b/t/test_umash_fp_multiple_blocks.py
@@ -1,0 +1,141 @@
+"""
+Test suite for the very long input fingerprinting subroutine.
+"""
+from hypothesis import given, note
+import hypothesis.strategies as st
+from umash import C, FFI
+from umash_reference import (
+    blockify_chunks,
+    chunk_bytes,
+    oh_compress,
+    poly_reduce,
+    UmashKey,
+)
+
+
+U64S = st.integers(min_value=0, max_value=2**64 - 1)
+
+
+FIELD = 2**61 - 1
+
+
+def repeats(size):
+    """Repeats one byte exactly size times."""
+    return st.binary(min_size=1, max_size=1).map(lambda binary: binary * size)
+
+
+def multiple_blocks_reference(keys, initials, seed, data):
+    def ref(key, initial, secondary):
+        blocks = blockify_chunks(chunk_bytes(data))
+        oh_values = oh_compress(key.oh, seed, blocks, secondary)
+        return poly_reduce(key.poly, len(data), oh_values, initial)
+
+    return [
+        ref(key, initial, secondary)
+        for key, initial, secondary in zip(keys, initials, [False, True])
+    ]
+
+
+@given(
+    initials=st.lists(U64S, min_size=2, max_size=2),
+    seed=U64S,
+    multipliers=st.lists(
+        st.integers(min_value=0, max_value=FIELD - 1), min_size=2, max_size=2
+    ),
+    key=st.lists(
+        U64S,
+        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+    ),
+    data=repeats(256)
+    | repeats(512)
+    | st.binary(min_size=256, max_size=256)
+    | st.binary(min_size=512, max_size=512),
+)
+def test_umash_fprint_multiple_blocks(initials, seed, multipliers, key, data):
+    """Compare umash_fprint_multiple_blocks with the reference on short
+    inputs: we only invoke `umash_fprint_multiple_blocks` on large
+    inputs purely for performance reasons.  With respect to pure
+    correctness, it should be OK to invoke on any number of integral
+    blocks.
+    """
+    assert len(data) % 256 == 0
+    expected = multiple_blocks_reference(
+        [UmashKey(poly=multipliers[0], oh=key), UmashKey(poly=multipliers[1], oh=key)],
+        initials,
+        seed,
+        data,
+    )
+    note(len(data))
+
+    n_bytes = len(data)
+    block = FFI.new("char[]", n_bytes)
+    FFI.memmove(block, data, n_bytes)
+    mul = FFI.new("uint64_t[2][2]")
+    for i in range(2):
+        mul[i][0] = (multipliers[i] ** 2) % FIELD
+        mul[i][1] = multipliers[i]
+
+    params = FFI.new("struct umash_params[1]")
+    for i, param in enumerate(key):
+        params[0].oh[i] = param
+
+    poly = FFI.new("struct umash_fp[1]")
+    poly[0].hash[0] = initials[0]
+    poly[0].hash[1] = initials[1]
+
+    actual = C.umash_fprint_multiple_blocks(
+        poly[0], mul, params[0].oh, seed, block, n_bytes // 256
+    )
+
+    assert [actual.hash[0], actual.hash[1]] == expected
+
+
+@given(
+    initials=st.lists(U64S, min_size=2, max_size=2),
+    seed=U64S,
+    multipliers=st.lists(
+        st.integers(min_value=0, max_value=FIELD - 1), min_size=2, max_size=2
+    ),
+    key=st.lists(
+        U64S,
+        min_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+        max_size=C.UMASH_OH_PARAM_COUNT + C.UMASH_OH_TWISTING_COUNT,
+    ),
+    data=st.lists(repeats(256), min_size=3, max_size=10).map(
+        lambda chunks: b"".join(chunks)
+    ),
+)
+def test_umash_fprint_multiple_blocks_repeat(initials, seed, multipliers, key, data):
+    """Compare umash_fprint_multiple_blocks with the reference on longer
+    inputs."""
+    assert len(data) % 256 == 0
+    expected = multiple_blocks_reference(
+        [UmashKey(poly=multipliers[0], oh=key), UmashKey(poly=multipliers[1], oh=key)],
+        initials,
+        seed,
+        data,
+    )
+    note(len(data))
+
+    n_bytes = len(data)
+    block = FFI.new("char[]", n_bytes)
+    FFI.memmove(block, data, n_bytes)
+    mul = FFI.new("uint64_t[2][2]")
+    for i in range(2):
+        mul[i][0] = (multipliers[i] ** 2) % FIELD
+        mul[i][1] = multipliers[i]
+
+    params = FFI.new("struct umash_params[1]")
+    for i, param in enumerate(key):
+        params[0].oh[i] = param
+
+    poly = FFI.new("struct umash_fp[1]")
+    poly[0].hash[0] = initials[0]
+    poly[0].hash[1] = initials[1]
+
+    actual = C.umash_fprint_multiple_blocks(
+        poly[0], mul, params[0].oh, seed, block, n_bytes // 256
+    )
+
+    assert [actual.hash[0], actual.hash[1]] == expected

--- a/t/umash_test_only.h
+++ b/t/umash_test_only.h
@@ -90,6 +90,16 @@ uint64_t umash_multiple_blocks_generic(uint64_t initial,
     const void *blocks, size_t n_blocks);
 
 /**
+ * Updates the 128-bit UMASH fingerprint state for `n_blocks` full
+ * 256-byte blocks: accepts the `initial` state as an argument and
+ * returns the update value.
+ *
+ * The block count `n_blocks` must be strictly positive.
+ */
+struct umash_fp umash_fprint_multiple_blocks(struct umash_fp initial,
+    const uint64_t multipliers[static 2][2], const uint64_t *oh, uint64_t seed,
+    const void *data, size_t n_blocks);
+/**
  * Converts a buffer of <= 8 bytes to a 64-bit integers.
  */
 uint64_t vec_to_u64(const void *data, size_t n_bytes);

--- a/umash_long.inc
+++ b/umash_long.inc
@@ -18,10 +18,21 @@ typedef uint64_t umash_multiple_blocks_fn(uint64_t initial,
     const uint64_t multipliers[static 2], const uint64_t *oh_ptr, uint64_t seed,
     const void *blocks, size_t n_blocks);
 
+typedef struct umash_fp umash_fprint_multiple_blocks_fn(struct umash_fp initial,
+    const uint64_t multipliers[static 2][2], const uint64_t *oh, uint64_t seed,
+    const void *data, size_t n_blocks);
+
 /**
- * Updates a 64-bit UMASH state for `n_blocks` 256-byte blocks in data.
+ * Updates a 64-bit UMASH state for `n_blocks` 256-byte blocks in
+ * `data`.
  */
 TEST_DEF umash_multiple_blocks_fn umash_multiple_blocks_generic;
+
+/**
+ * Updates a 128-bit UMASH fingerprint state for `n_blocks` 256-byte
+ * blocks in `data`.
+ */
+TEST_DEF umash_fprint_multiple_blocks_fn umash_fprint_multiple_blocks;
 
 /**
  * Runtime dispatch logic.  When dynamic dispatch is enabled,
@@ -406,3 +417,36 @@ umash_multiple_blocks_vpclmulqdq(uint64_t initial, const uint64_t multipliers[st
 	return split_accumulator_eval(ret);
 }
 #endif
+
+TEST_DEF void oh_varblock_fprint(struct umash_oh dst[static restrict 2],
+    const uint64_t *restrict params, uint64_t tag, const void *restrict block,
+    size_t n_bytes);
+
+TEST_DEF HOT struct umash_fp
+umash_fprint_multiple_blocks(struct umash_fp initial,
+    const uint64_t multipliers[static 2][2], const uint64_t *oh, uint64_t seed,
+    const void *data, size_t n_blocks)
+{
+	const uint64_t m00 = multipliers[0][0];
+	const uint64_t m01 = multipliers[0][1];
+	const uint64_t m10 = multipliers[1][0];
+	const uint64_t m11 = multipliers[1][1];
+	uint64_t acc0 = initial.hash[0];
+	uint64_t acc1 = initial.hash[1];
+
+	do {
+		struct umash_oh compressed[2];
+
+		oh_varblock_fprint(compressed, oh, seed, data, BLOCK_SIZE);
+		acc0 = horner_double_update(
+		    acc0, m00, m01, compressed[0].bits[0], compressed[0].bits[1]);
+		acc1 = horner_double_update(
+		    acc1, m10, m11, compressed[1].bits[0], compressed[1].bits[1]);
+
+		data = (const char *)data + BLOCK_SIZE;
+	} while (--n_blocks);
+
+	return (struct umash_fp) {
+                .hash = { acc0, acc1, },
+        };
+}


### PR DESCRIPTION
and divert fingerprinting calls to it.

For now, the new function is just a pure copy of the regular code
path: let's start by adding test coverage before we try to improve
performance.

TESTED=new and existing tests.
