### PR TITLE
umash_long: force less parallelism in `umash_fprint_multiple_blocks`

### DIFF
--- a/umash_long.inc
+++ b/umash_long.inc
@@ -470,20 +470,35 @@ umash_fprint_multiple_blocks(struct umash_fp initial,
 	} while (0)
 
 		TWIST(0);
+                FORCE();
 		TWIST(2);
+                FORCE();
 		TWIST(4);
+                FORCE();
 		TWIST(6);
+                FORCE();
 		TWIST(8);
+                FORCE();
 		TWIST(10);
+                FORCE();
 		TWIST(12);
+                FORCE();
 		TWIST(14);
+                FORCE();
 		TWIST(16);
+                FORCE();
 		TWIST(18);
+                FORCE();
 		TWIST(20);
+                FORCE();
 		TWIST(22);
+                FORCE();
 		TWIST(24);
+                FORCE();
 		TWIST(26);
+                FORCE();
 		TWIST(28);
+                FORCE();
 
 #undef TWIST
 #undef FORCE


### PR DESCRIPTION
Compilers want to use a reduction tree instead of a linear xor
reduction chain when combining PH-mixed values.  In practice, that's
far from the bottleneck, especially on machines with out-of-order
execution.  It's much more important to minimise register pressure
and avoid wasting instructions on reloading from the stack.

Shaves 23% off the code footprint of `umash_fprint_multiple_blocks`,
from 1535 to 1183 bytes, on gcc 8.3.

Small mixed impact on shorter strings, maybe compensates for half the
slowdown introduced by unrolling `umash_fprint_multiple_blocks`.

```
[(32,
  {'mean': Result(actual_value=-0.9456688877498719, judgement=-1, m=7812, n=7812, num_trials=2750000),
   'lte': Result(actual_value=0.8673506748057067, judgement=1, m=7812, n=7812, num_trials=2750000),
   'q99': Result(actual_value=-20.0, judgement=0, m=7812, n=7812, num_trials=62500),
   'q99_sa': Result(actual_value=-20.0, judgement=-1, m=7812, n=7812, num_trials=2750000)}),
 (64,
  {'mean': Result(actual_value=0.33933933933933935, judgement=0, m=20000, n=20000, num_trials=4250000),
   'lte': Result(actual_value=0.827651725, judgement=0, m=20000, n=20000, num_trials=9250),
   'q99': Result(actual_value=0.0, judgement=0, m=20000, n=20000, num_trials=250),
   'q99_sa': Result(actual_value=0.0, judgement=-1, m=20000, n=20000, num_trials=2750000)}),
 (96,
  {'mean': Result(actual_value=0.8228228228228228, judgement=1, m=20000, n=20000, num_trials=2750000),
   'lte': Result(actual_value=0.7118781525, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'q99': Result(actual_value=0.0, judgement=0, m=20000, n=20000, num_trials=250),
   'q99_sa': Result(actual_value=0.0, judgement=-1, m=20000, n=20000, num_trials=2750000)}),
 (128,
  {'mean': Result(actual_value=0.7077077077077077, judgement=1, m=20000, n=20000, num_trials=2750000),
   'lte': Result(actual_value=0.7768927975, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'q99': Result(actual_value=0.0, judgement=0, m=20000, n=20000, num_trials=250),
   'q99_sa': Result(actual_value=0.0, judgement=-1, m=20000, n=20000, num_trials=2750000)}),
 (192,
  {'mean': Result(actual_value=0.5985985985985987, judgement=1, m=20000, n=20000, num_trials=12500000),
   'lte': Result(actual_value=0.7706339675, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'q99': Result(actual_value=0.0, judgement=0, m=20000, n=20000, num_trials=250),
   'q99_sa': Result(actual_value=0.0, judgement=-1, m=20000, n=20000, num_trials=2750000)}),
 (256,
  {'mean': Result(actual_value=0.6537156953438175, judgement=0, m=3247, n=3247, num_trials=250),
   'lte': Result(actual_value=0.6239123005585976, judgement=0, m=3247, n=3247, num_trials=250),
   'q99': Result(actual_value=0.0, judgement=0, m=3247, n=3247, num_trials=250),
   'q99_sa': Result(actual_value=0.0, judgement=0, m=3247, n=3247, num_trials=250)}),
 (384,
  {'mean': Result(actual_value=-7.756788665879575, judgement=-1, m=1696, n=1696, num_trials=2750000),
   'lte': Result(actual_value=0.8157564830678177, judgement=1, m=1696, n=1696, num_trials=2750000),
   'q99': Result(actual_value=0.0, judgement=0, m=1696, n=1696, num_trials=250),
   'q99_sa': Result(actual_value=0.0, judgement=0, m=1696, n=1696, num_trials=20000)}),
 (512,
  {'mean': Result(actual_value=-4.396551724137931, judgement=0, m=234, n=234, num_trials=250),
   'lte': Result(actual_value=0.6761816056687852, judgement=0, m=234, n=234, num_trials=250),
   'q99': Result(actual_value=-40.0, judgement=0, m=234, n=234, num_trials=250),
   'q99_sa': Result(actual_value=-40.0, judgement=0, m=234, n=234, num_trials=20000)}),
 (640,
  {'mean': Result(actual_value=-45.42857142857143, judgement=0, m=72, n=72, num_trials=250),
   'lte': Result(actual_value=0.6284722222222222, judgement=0, m=72, n=72, num_trials=250),
   'q99': Result(actual_value=0.0, judgement=0, m=72, n=72, num_trials=250),
   'q99_sa': Result(actual_value=0.0, judgement=0, m=72, n=72, num_trials=250)})]
```

Speeds up fingerprinting of 64 KB inputs by ~8% (14740 -> 13620
cycles).

```
[(65536,
  {'mean': Result(actual_value=-571.1151151151151, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'lte': Result(actual_value=0.995977375, judgement=1, m=20000, n=20000, num_trials=2750000),
   'q99': Result(actual_value=-480.0, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'q99_sa': Result(actual_value=-480.0, judgement=-1, m=20000, n=20000, num_trials=2750000)})]
```

Fingerprint equivalent of 44049eef, part of #21.

TESTED=existing tests.