### PR TITLE
umash_long.inc: use lazy reduction for fingerprint's acc0

### DIFF
--- a/umash_long.inc
+++ b/umash_long.inc
@@ -433,7 +433,7 @@ umash_fprint_multiple_blocks(struct umash_fp initial,
 	const uint64_t m01 = multipliers[0][1];
 	const uint64_t m10 = multipliers[1][0];
 	const uint64_t m11 = multipliers[1][1];
-	uint64_t acc0 = initial.hash[0];
+	struct split_accumulator acc0 = { .base = initial.hash[0] };
 	uint64_t acc1 = initial.hash[1];
 
 	do {
@@ -541,13 +541,13 @@ umash_fprint_multiple_blocks(struct umash_fp initial,
 			compressed[1].bits[1] ^= enh_hi;
 		}
 
-		acc0 = horner_double_update(
+		acc0 = split_accumulator_update(
 		    acc0, m00, m01, compressed[0].bits[0], compressed[0].bits[1]);
 		acc1 = horner_double_update(
 		    acc1, m10, m11, compressed[1].bits[0], compressed[1].bits[1]);
 	} while (--n_blocks);
 
 	return (struct umash_fp) {
-                .hash = { acc0, acc1, },
+                .hash = { split_accumulator_eval(acc0), acc1, },
         };
 }


### PR DESCRIPTION
The primary hash's dependency chain is shorter; let's start by using
lazy reduction (which has an additional fixup step at the end) for
that one.

A 1-2% speed-up for 64 KB inputs.

```
[(65536,
  {'mean': Result(actual_value=-133.08408408408408, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'lte': Result(actual_value=0.6678323024999999, judgement=1, m=20000, n=20000, num_trials=2750000),
   'q99': Result(actual_value=-260.0, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'q99_sa': Result(actual_value=-260.0, judgement=-1, m=20000, n=20000, num_trials=2750000)})]
```

Part of #21.

TESTED=existing tests