### PR TITLE
umash_long.inc: use lazy reduction for the other polynomial accumulator

### DIFF
--- a/umash_long.inc
+++ b/umash_long.inc
@@ -434,7 +434,7 @@ umash_fprint_multiple_blocks(struct umash_fp initial,
 	const uint64_t m10 = multipliers[1][0];
 	const uint64_t m11 = multipliers[1][1];
 	struct split_accumulator acc0 = { .base = initial.hash[0] };
-	uint64_t acc1 = initial.hash[1];
+	struct split_accumulator acc1 = { .base = initial.hash[1] };
 
 	do {
 		struct umash_oh compressed[2];
@@ -543,11 +543,14 @@ umash_fprint_multiple_blocks(struct umash_fp initial,
 
 		acc0 = split_accumulator_update(
 		    acc0, m00, m01, compressed[0].bits[0], compressed[0].bits[1]);
-		acc1 = horner_double_update(
+		acc1 = split_accumulator_update(
 		    acc1, m10, m11, compressed[1].bits[0], compressed[1].bits[1]);
 	} while (--n_blocks);
 
 	return (struct umash_fp) {
-                .hash = { split_accumulator_eval(acc0), acc1, },
+                .hash = {
+                        split_accumulator_eval(acc0),
+                        split_accumulator_eval(acc1),
+                },
         };
 }


### PR DESCRIPTION
A 4-5% speed-up for 64 KB inputs.

![newplot (13)](https://user-images.githubusercontent.com/704703/155638833-e4f92677-6117-4e2a-aefd-86f04aa393ca.png)

```
[(65536,
  {'mean': Result(actual_value=-712.8128128128128, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'lte': Result(actual_value=0.9960576625, judgement=1, m=20000, n=20000, num_trials=2750000),
   'q99': Result(actual_value=-740.0, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'q99_sa': Result(actual_value=-740.0, judgement=-1, m=20000, n=20000, num_trials=2750000)})]
```

No great significant impact either way on shorter strings

```
[(32,
  {'mean': Result(actual_value=-0.6509482316760635, judgement=-1, m=7812, n=7812, num_trials=4000000),
   'lte': Result(actual_value=0.8886713962187179, judgement=0, m=7812, n=7812, num_trials=2000),
   'q99': Result(actual_value=-20.0, judgement=0, m=7812, n=7812, num_trials=250),
   'q99_sa': Result(actual_value=-20.0, judgement=-1, m=7812, n=7812, num_trials=2750000)}),
 (64,
  {'mean': Result(actual_value=-1.2252252252252251, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'lte': Result(actual_value=0.88791628, judgement=1, m=20000, n=20000, num_trials=2750000),
   'q99': Result(actual_value=0.0, judgement=0, m=20000, n=20000, num_trials=250),
   'q99_sa': Result(actual_value=0.0, judgement=-1, m=20000, n=20000, num_trials=2750000)}),
 (96,
  {'mean': Result(actual_value=1.0940940940940942, judgement=1, m=20000, n=20000, num_trials=2750000),
   'lte': Result(actual_value=0.700120335, judgement=0, m=20000, n=20000, num_trials=2250),
   'q99': Result(actual_value=0.0, judgement=0, m=20000, n=20000, num_trials=250),
   'q99_sa': Result(actual_value=0.0, judgement=-1, m=20000, n=20000, num_trials=2750000)}),
 (128,
  {'mean': Result(actual_value=0.988988988988989, judgement=1, m=20000, n=20000, num_trials=2750000),
   'lte': Result(actual_value=0.778723715, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'q99': Result(actual_value=0.0, judgement=0, m=20000, n=20000, num_trials=250),
   'q99_sa': Result(actual_value=0.0, judgement=-1, m=20000, n=20000, num_trials=2750000)}),
 (192,
  {'mean': Result(actual_value=0.4744744744744745, judgement=0, m=20000, n=20000, num_trials=67500),
   'lte': Result(actual_value=0.785697205, judgement=-1, m=20000, n=20000, num_trials=30000000),
   'q99': Result(actual_value=0.0, judgement=0, m=20000, n=20000, num_trials=250),
   'q99_sa': Result(actual_value=0.0, judgement=-1, m=20000, n=20000, num_trials=2750000)}),
 (256,
  {'mean': Result(actual_value=-0.4316990440949738, judgement=0, m=3247, n=3247, num_trials=250),
   'lte': Result(actual_value=0.6395967223398937, judgement=0, m=3247, n=3247, num_trials=250),
   'q99': Result(actual_value=0.0, judgement=0, m=3247, n=3247, num_trials=250),
   'q99_sa': Result(actual_value=0.0, judgement=0, m=3247, n=3247, num_trials=250)}),
 (384,
  {'mean': Result(actual_value=1.3577331759149942, judgement=0, m=1696, n=1696, num_trials=250),
   'lte': Result(actual_value=0.6643023818529725, judgement=0, m=1696, n=1696, num_trials=250),
   'q99': Result(actual_value=20.0, judgement=0, m=1696, n=1696, num_trials=250),
   'q99_sa': Result(actual_value=20.0, judgement=0, m=1696, n=1696, num_trials=250)}),
 (512,
  {'mean': Result(actual_value=-1.1206896551724137, judgement=0, m=234, n=234, num_trials=250),
   'lte': Result(actual_value=0.6175213675213675, judgement=0, m=234, n=234, num_trials=250),
   'q99': Result(actual_value=0.0, judgement=0, m=234, n=234, num_trials=250),
   'q99_sa': Result(actual_value=0.0, judgement=0, m=234, n=234, num_trials=250)}),
 (640,
  {'mean': Result(actual_value=-8.857142857142858, judgement=0, m=72, n=72, num_trials=250),
   'lte': Result(actual_value=0.552662037037037, judgement=0, m=72, n=72, num_trials=250),
   'q99': Result(actual_value=300.0, judgement=0, m=72, n=72, num_trials=250),
   'q99_sa': Result(actual_value=300.0, judgement=0, m=72, n=72, num_trials=250)})]
```

TESTED=run-tests.sh