### PR TITLE
umash_long: remove forced serialisaion in VPCLMULQDQ fprint

### DIFF
--- a/umash_long.inc
+++ b/umash_long.inc
@@ -704,7 +704,6 @@ umash_fprint_multiple_blocks_vpclmulqdq(struct umash_fp initial,
 
 		data = (const char *)data + BLOCK_SIZE;
 
-#define FORCE() __asm__("" : "+x"(acc2), "+x"(acc_shifted2), "+x"(lrc2), "+x"(prev2))
 #define TWIST(I)                                                   \
 	do {                                                       \
 		__m256i x;                                         \
@@ -723,22 +722,14 @@ umash_fprint_multiple_blocks_vpclmulqdq(struct umash_fp initial,
 	} while (0)
 
 		TWIST(0);
-		FORCE();
 		TWIST(4);
-		FORCE();
 		TWIST(8);
-		FORCE();
 		TWIST(12);
-		FORCE();
 		TWIST(16);
-		FORCE();
 		TWIST(20);
-		FORCE();
 		TWIST(24);
-		FORCE();
 
 #undef TWIST
-#undef FORCE
 
 		{
 			__m256i x;


### PR DESCRIPTION
There's much less register pressure when registers span 256 instead of
128 bits, so messing with the compiler's scheduling is net loss: 9060
-> 8820 cycles on an EPYC 7713.

![newplot (9)](https://user-images.githubusercontent.com/704703/155845468-ee95199b-715d-4bbf-951c-5e9147500add.png)

```
[(65536,
  {'mean': Result(actual_value=-252.52352352352352, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'lte': Result(actual_value=0.9918745625, judgement=1, m=20000, n=20000, num_trials=2750000),
   'q99': Result(actual_value=-1860.0, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'q99_sa': Result(actual_value=-1860.0, judgement=-1, m=20000, n=20000, num_trials=2750000)})]
```

TESTED=existing tests.