### PR TITLE
umash_long: simplify generic bulk fprint function

### DIFF
--- a/umash_long.inc
+++ b/umash_long.inc
@@ -388,13 +388,12 @@ umash_fprint_multiple_blocks_generic(struct umash_fp initial,
 		v128 acc = V128_ZERO; /* Base umash */
 		v128 acc_shifted = V128_ZERO; /* Accumulates shifted values */
 		v128 lrc = lrc_init;
-		v128 prev = V128_ZERO;
 		const void *block = data;
 
 		data = (const char *)data + BLOCK_SIZE;
 
 #if UMASH_INLINE_ASM
-#define FORCE() __asm__("" : "+x"(acc), "+x"(acc_shifted), "+x"(lrc), "+x"(prev))
+#define FORCE() __asm__("" : "+x"(acc), "+x"(acc_shifted), "+x"(lrc))
 #else
 #define FORCE() ((void)0)
 #endif
@@ -415,10 +414,11 @@ umash_fprint_multiple_blocks_generic(struct umash_fp initial,
                                                          \
 		acc ^= x;                                \
                                                          \
-		acc_shifted ^= prev;                     \
-		acc_shifted = v128_shift(acc_shifted);   \
+		if (I == 28)                             \
+			break;                           \
                                                          \
-		prev = x;                                \
+		acc_shifted ^= x;                        \
+		acc_shifted = v128_shift(acc_shifted);   \
 	} while (0)
 
 		TWIST(0);


### PR DESCRIPTION
When fingerprinting large inputs, it's trivial to determine when we're
processing the last PH chunk in a block: the loop is fully unrolled.

We can thus simplify the logic for the "shifted" PH accumulator,
and save a register.  This improves throughput for the generic
code path on an EPYC 7713 by ~3.5% (13120 -> 12680 cycles).

![newplot (14)](https://user-images.githubusercontent.com/704703/155861548-7ac4b63c-1aae-4413-bf4b-6bcb748b599c.png)

```
[(65536,
  {'mean': Result(actual_value=-524.5595595595596, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'lte': Result(actual_value=0.803463475, judgement=1, m=20000, n=20000, num_trials=2750000),
   'q99': Result(actual_value=-2520.0, judgement=-1, m=20000, n=20000, num_trials=2750000),
   'q99_sa': Result(actual_value=-2520.0, judgement=-1, m=20000, n=20000, num_trials=2750000)})]
```

TESTED=existing tests, on a machine that does not have VPCLMULQDQ.